### PR TITLE
Add additional time units.

### DIFF
--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -36,5 +36,11 @@ quantity! {
         @attosecond: prefix!(atto); "as", "attosecond", "attoseconds";
         @zeptosecond: prefix!(zepto); "zs", "zeptosecond", "zeptoseconds";
         @yoctosecond: prefix!(yocto); "ys", "yoctosecond", "yoctoseconds";
+
+        @day: 8.64_E4; "d", "day", "days";
+        @hour: 3.6_E3; "h", "hour", "hours";
+        @minute: 6.0_E1; "m", "minute", "minutes";
+        @shake: 1.0_E-8; "10.0 ns", "shake", "shakes";
+        @year: 3.1536_E7; "y", "year", "years";
     }
 }


### PR DESCRIPTION
Hi,
I've added the non sidereal, non tropical time units from [https://www.nist.gov/pml/nist-guide-si-appendix-b9-factors-units-listed-kind-quantity-or-field-science#TIME](https://www.nist.gov/pml/nist-guide-si-appendix-b9-factors-units-listed-kind-quantity-or-field-science#TIME).

Issue #4 

I've followed the style found in lenght.rs, let me know if you want me to change anything.