### PR TITLE
Add separate testcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ travis-ci = { repository = "iliekturtles/uom" }
 coveralls = { repository = "iliekturtles/uom" }
 maintenance = { status = "actively-developed" }
 
+[workspace]
+members = ["testcrate"]
+default-members = [".", "testcrate"]
+
 [dependencies]
 num = "0.1"
 serde = { version = "1.0", optional = true, default-features = false }

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "testcrate"
+version = "0.1.0"
+authors = ["Wim Looman <wim@nemo157.com>"]
+
+[dependencies]
+uom = { path = ".." }
+
+[[example]]
+name = "base"
+path = "../examples/base.rs"
+
+[[example]]
+name = "mks"
+path = "../examples/mks.rs"
+
+[[example]]
+name = "si"
+path = "../examples/si.rs"


### PR DESCRIPTION
Allows testing without inheriting features from the uom build, is tested
when running `cargo test` automatically be being a workspace member, so
will be tested on travis and appveyor. Includes all the examples from
uom so that these examples are tested as if they were part of a separate
application.

See previous discussion at #62. This is used for testing whether #61 is fixed.