### PR TITLE
Fix current documentation copy-paste error.

### DIFF
--- a/src/si/electric_current.rs
+++ b/src/si/electric_current.rs
@@ -3,7 +3,7 @@
 quantity! {
     /// Electric current (base unit ampere, A<sup>1</sup>).
     quantity: ElectricCurrent; "electric current";
-    /// Amount of substance dimension, mol<sup>1</sup>.
+    /// Electric current dimension, A<sup>1</sup>.
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass


### PR DESCRIPTION
`electric_current.rs` currently has a minor [documentation error](https://github.com/iliekturtles/uom/blob/7d7cab0e3e35fe38d8eba5d2f6d56f74103b9da2/src/si/electric_current.rs#L6) stemming from a copy-paste that wasn't properly edited. This is a very minor thing, but obviously worth fixing.