### PR TITLE
Removed unused `_unit: N` parameters and require turbofish.

### DIFF
--- a/examples/mks.rs
+++ b/examples/mks.rs
@@ -10,9 +10,9 @@ fn main() {
 
     println!(
         "{:?} {} = {:?} {}",
-        l1.get(meter),
+        l1.get::<meter>(),
         meter::abbreviation(),
-        l1.get(foot),
+        l1.get::<foot>(),
         foot::abbreviation()
     );
 }

--- a/examples/si.rs
+++ b/examples/si.rs
@@ -17,38 +17,38 @@ fn main() {
 
     println!(
         "{:?} {} + {:?} {} = {:?} {}",
-        l1.get(meter),
+        l1.get::<meter>(),
         meter::abbreviation(),
-        l2.get(centimeter),
+        l2.get::<centimeter>(),
         centimeter::abbreviation(),
-        (l1 + l2).get(meter),
+        (l1 + l2).get::<meter>(),
         meter::abbreviation()
     );
     println!(
         "{:?} {} + {:?} {} = {:?} {}",
-        l1.get(meter),
+        l1.get::<meter>(),
         meter::abbreviation(),
-        l2.get(centimeter),
+        l2.get::<centimeter>(),
         centimeter::abbreviation(),
-        (l1 + l2).get(kilometer),
+        (l1 + l2).get::<kilometer>(),
         kilometer::abbreviation()
     );
     println!(
         "{:?} {} / {:?} {} = {:?} {}",
-        l1.get(meter),
+        l1.get::<meter>(),
         meter::abbreviation(),
-        t1.get(second),
+        t1.get::<second>(),
         second::abbreviation(),
-        v1.get(meter_per_second),
+        v1.get::<meter_per_second>(),
         meter_per_second::abbreviation()
     );
     println!(
         "{:?} {} / {:?} {} = {:?} {}",
-        l1.get(meter),
+        l1.get::<meter>(),
         meter::abbreviation(),
-        t1.get(second),
+        t1.get::<second>(),
         second::abbreviation(),
-        v1.get(kilometer_per_second),
+        v1.get::<kilometer_per_second>(),
         kilometer_per_second::abbreviation()
     );
 }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -237,7 +237,7 @@ macro_rules! quantity {
 
             /// Retrieve the value of the quantity in the given measurement unit.
             #[inline(always)]
-            pub fn get<N>(&self, _unit: N) -> V
+            pub fn get<N>(&self) -> V
             where
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
@@ -247,54 +247,54 @@ macro_rules! quantity {
             /// Returns the largest integer less than or equal to a number in the given
             /// measurement unit.
             #[inline(always)]
-            pub fn floor<N>(self, _unit: N) -> Self
+            pub fn floor<N>(self) -> Self
             where
                 V: $crate::num::Float,
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
-                Self::new::<N>(self.get(_unit).floor())
+                Self::new::<N>(self.get::<N>().floor())
             }
 
             /// Returns the smallest integer less than or equal to a number in the given
             /// measurement unit.
             #[inline(always)]
-            pub fn ceil<N>(self, _unit: N) -> Self
+            pub fn ceil<N>(self) -> Self
             where
                 V: $crate::num::Float,
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
-                Self::new::<N>(self.get(_unit).ceil())
+                Self::new::<N>(self.get::<N>().ceil())
             }
 
             /// Returns the nearest integer to a number in the in given measurement unit.
             /// Round half-way cases away from 0.0.
             #[inline(always)]
-            pub fn round<N>(self, _unit: N) -> Self
+            pub fn round<N>(self) -> Self
             where
                 V: $crate::num::Float,
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
-                Self::new::<N>(self.get(_unit).round())
+                Self::new::<N>(self.get::<N>().round())
             }
 
             /// Returns the integer part of a number in the given measurement unit.
             #[inline(always)]
-            pub fn trunc<N>(self, _unit: N) -> Self
+            pub fn trunc<N>(self) -> Self
             where
                 V: $crate::num::Float,
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
-                Self::new::<N>(self.get(_unit).trunc())
+                Self::new::<N>(self.get::<N>().trunc())
             }
 
             /// Returns the fractional part of a number in the given measurement unit.
             #[inline(always)]
-            pub fn fract<N>(self, _unit: N) -> Self
+            pub fn fract<N>(self) -> Self
             where
                 V: $crate::num::Float,
                 N: Unit + $crate::Conversion<V, T = V::T>,
             {
-                Self::new::<N>(self.get(_unit).fract())
+                Self::new::<N>(self.get::<N>().fract())
             }
         }
     };

--- a/src/si/length.rs
+++ b/src/si/length.rs
@@ -92,7 +92,7 @@ mod tests {
             #[allow(trivial_casts)]
             fn hypot(l: V, r: V) -> bool {
                 Test::eq(&l.hypot(r),
-                    &Length::new::<meter>(l).hypot(Length::new::<meter>(r)).get(meter))
+                    &Length::new::<meter>(l).hypot(Length::new::<meter>(r)).get::<meter>())
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,11 +229,11 @@ mod quantity_macro {
             let l2 = Length::new::<meter>(V::one());
             let m1 = Mass::new::<kilogram>(V::one());
 
-            Test::assert_eq(&V::from_f64(1000.0).unwrap(), &l1.get(meter));
-            Test::assert_eq(&V::one(), &l2.get(meter));
-            Test::assert_eq(&V::one(), &l1.get(kilometer));
-            Test::assert_eq(&V::from_f64(0.001).unwrap(), &l2.get(kilometer));
-            Test::assert_eq(&V::one(), &m1.get(kilogram));
+            Test::assert_eq(&V::from_f64(1000.0).unwrap(), &l1.get::<meter>());
+            Test::assert_eq(&V::one(), &l2.get::<meter>());
+            Test::assert_eq(&V::one(), &l1.get::<kilometer>());
+            Test::assert_eq(&V::from_f64(0.001).unwrap(), &l2.get::<kilometer>());
+            Test::assert_eq(&V::one(), &m1.get::<kilogram>());
         }
 
         #[test]
@@ -279,16 +279,16 @@ mod quantity_macro {
                 let m1 = Mass::new::<kilogram>(3.9999);
                 let m2 = Mass::new::<kilogram>(3.0001);
 
-                Test::assert_eq(&3.0, &l1.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3999.0, &l1.floor(meter).get(meter));
-                Test::assert_eq(&3.0, &l2.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3000.0, &l2.floor(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.floor(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l4.floor(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.floor(kilogram).get(kilogram));
-                Test::assert_eq(&3.0, &m2.floor(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3999.0, &l1.floor::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &l2.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3000.0, &l2.floor::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.floor::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l4.floor::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.floor::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&3.0, &m2.floor::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -300,16 +300,16 @@ mod quantity_macro {
                 let m1 = Mass::new::<kilogram>(3.9999);
                 let m2 = Mass::new::<kilogram>(3.0001);
 
-                Test::assert_eq(&4.0, &l1.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4000.0, &l1.ceil(meter).get(meter));
-                Test::assert_eq(&4.0, &l2.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&3001.0, &l2.ceil(meter).get(meter));
-                Test::assert_eq(&1.0, &l3.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l3.ceil(meter).get(meter));
-                Test::assert_eq(&1.0, &l4.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l4.ceil(meter).get(meter));
-                Test::assert_eq(&4.0, &m1.ceil(kilogram).get(kilogram));
-                Test::assert_eq(&4.0, &m2.ceil(kilogram).get(kilogram));
+                Test::assert_eq(&4.0, &l1.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4000.0, &l1.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &l2.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3001.0, &l2.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&1.0, &l3.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l3.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&1.0, &l4.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l4.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &m1.ceil::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&4.0, &m2.ceil::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -321,16 +321,16 @@ mod quantity_macro {
                 let m1 = Mass::new::<kilogram>(3.3);
                 let m2 = Mass::new::<kilogram>(3.5);
 
-                Test::assert_eq(&3.0, &l1.round(kilometer).get(kilometer));
-                Test::assert_eq(&3300.0, &l1.round(meter).get(meter));
-                Test::assert_eq(&4.0, &l2.round(kilometer).get(kilometer));
-                Test::assert_eq(&3500.0, &l2.round(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.round(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.round(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.round(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l4.round(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.round(kilogram).get(kilogram));
-                Test::assert_eq(&4.0, &m2.round(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3300.0, &l1.round::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &l2.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3500.0, &l2.round::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.round::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l4.round::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.round::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&4.0, &m2.round::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -342,16 +342,16 @@ mod quantity_macro {
                 let m1 = Mass::new::<kilogram>(3.3);
                 let m2 = Mass::new::<kilogram>(3.5);
 
-                Test::assert_eq(&3.0, &l1.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3300.0, &l1.trunc(meter).get(meter));
-                Test::assert_eq(&3.0, &l2.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3500.0, &l2.trunc(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.trunc(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l4.trunc(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.trunc(kilogram).get(kilogram));
-                Test::assert_eq(&3.0, &m2.trunc(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3300.0, &l1.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &l2.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3500.0, &l2.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l4.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.trunc::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&3.0, &m2.trunc::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -360,19 +360,19 @@ mod quantity_macro {
                 let l2 = Length::new::<meter>(3.3);
                 let m1 = Mass::new::<kilogram>(3.3);
 
-                Test::assert_eq(&3.3.fract(), &l1.fract(kilometer).get(kilometer));
-                Test::assert_eq(&(3.3.fract() * 1000.0), &l1.fract(kilometer).get(meter));
+                Test::assert_eq(&3.3.fract(), &l1.fract::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&(3.3.fract() * 1000.0), &l1.fract::<kilometer>().get::<meter>());
                 Test::assert_eq(&((3.3 * 1000.0).fract() / 1000.0),
-                    &l1.fract(meter).get(kilometer));
-                Test::assert_eq(&(3.3 * 1000.0).fract(), &l1.fract(meter).get(meter));
+                    &l1.fract::<meter>().get::<kilometer>());
+                Test::assert_eq(&(3.3 * 1000.0).fract(), &l1.fract::<meter>().get::<meter>());
 
-                Test::assert_eq(&(3.3 / 1000.0).fract(), &l2.fract(kilometer).get(kilometer));
+                Test::assert_eq(&(3.3 / 1000.0).fract(), &l2.fract::<kilometer>().get::<kilometer>());
                 Test::assert_eq(&((3.3 / 1000.0).fract() * 1000.0),
-                    &l2.fract(kilometer).get(meter));
-                Test::assert_eq(&(3.3.fract() / 1000.0), &l2.fract(meter).get(kilometer));
-                Test::assert_eq(&3.3.fract(), &l2.fract(meter).get(meter));
+                    &l2.fract::<kilometer>().get::<meter>());
+                Test::assert_eq(&(3.3.fract() / 1000.0), &l2.fract::<meter>().get::<kilometer>());
+                Test::assert_eq(&3.3.fract(), &l2.fract::<meter>().get::<meter>());
 
-                Test::assert_eq(&3.3.fract(), &m1.fract(kilogram).get(kilogram));
+                Test::assert_eq(&3.3.fract(), &m1.fract::<kilogram>().get::<kilogram>());
             }
         }
     }
@@ -584,14 +584,14 @@ mod system_macro {
                 fn saturating_add(l: A<V>, r: A<V>) -> bool {
                     Test::eq(&(l.saturating_add(*r)),
                         &(Length::new::<meter>((*l).clone())
-                            .saturating_add(Length::new::<meter>((*r).clone())).get(meter)))
+                            .saturating_add(Length::new::<meter>((*r).clone())).get::<meter>()))
                 }
 
                 #[allow(trivial_casts)]
                 fn saturating_sub(l: A<V>, r: A<V>) -> bool {
                     Test::eq(&(l.saturating_sub(*r)),
                         &(Length::new::<meter>((*l).clone())
-                            .saturating_sub(Length::new::<meter>((*r).clone())).get(meter)))
+                            .saturating_sub(Length::new::<meter>((*r).clone())).get::<meter>()))
                 }
             }
         }
@@ -948,11 +948,11 @@ mod quantities_macro {
             let l2 = k::Length::new::<meter>(V::one());
             let m1 = k::Mass::new::<kilogram>(V::one());
 
-            Test::assert_eq(&V::from_f64(1000.0).unwrap(), &l1.get(meter));
-            Test::assert_eq(&V::one(), &l2.get(meter));
-            Test::assert_eq(&V::one(), &l1.get(kilometer));
-            Test::assert_eq(&V::from_f64(0.001).unwrap(), &l2.get(kilometer));
-            Test::assert_eq(&V::one(), &m1.get(kilogram));
+            Test::assert_eq(&V::from_f64(1000.0).unwrap(), &l1.get::<meter>());
+            Test::assert_eq(&V::one(), &l2.get::<meter>());
+            Test::assert_eq(&V::one(), &l1.get::<kilometer>());
+            Test::assert_eq(&V::from_f64(0.001).unwrap(), &l2.get::<kilometer>());
+            Test::assert_eq(&V::one(), &m1.get::<kilogram>());
         }
 
         quickcheck! {
@@ -1156,16 +1156,16 @@ mod quantities_macro {
                 let m1 = k::Mass::new::<kilogram>(3.9999);
                 let m2 = k::Mass::new::<kilogram>(3.0001);
 
-                Test::assert_eq(&3.0, &l1.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3999.0, &l1.floor(meter).get(meter));
-                Test::assert_eq(&3.0, &l2.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3000.0, &l2.floor(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.floor(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.floor(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l4.floor(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.floor(kilogram).get(kilogram));
-                Test::assert_eq(&3.0, &m2.floor(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3999.0, &l1.floor::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &l2.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3000.0, &l2.floor::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.floor::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.floor::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l4.floor::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.floor::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&3.0, &m2.floor::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -1177,16 +1177,16 @@ mod quantities_macro {
                 let m1 = k::Mass::new::<kilogram>(3.9999);
                 let m2 = k::Mass::new::<kilogram>(3.0001);
 
-                Test::assert_eq(&4.0, &l1.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4000.0, &l1.ceil(meter).get(meter));
-                Test::assert_eq(&4.0, &l2.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&3001.0, &l2.ceil(meter).get(meter));
-                Test::assert_eq(&1.0, &l3.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l3.ceil(meter).get(meter));
-                Test::assert_eq(&1.0, &l4.ceil(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l4.ceil(meter).get(meter));
-                Test::assert_eq(&4.0, &m1.ceil(kilogram).get(kilogram));
-                Test::assert_eq(&4.0, &m2.ceil(kilogram).get(kilogram));
+                Test::assert_eq(&4.0, &l1.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4000.0, &l1.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &l2.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3001.0, &l2.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&1.0, &l3.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l3.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&1.0, &l4.ceil::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l4.ceil::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &m1.ceil::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&4.0, &m2.ceil::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -1198,16 +1198,16 @@ mod quantities_macro {
                 let m1 = k::Mass::new::<kilogram>(3.3);
                 let m2 = k::Mass::new::<kilogram>(3.5);
 
-                Test::assert_eq(&3.0, &l1.round(kilometer).get(kilometer));
-                Test::assert_eq(&3300.0, &l1.round(meter).get(meter));
-                Test::assert_eq(&4.0, &l2.round(kilometer).get(kilometer));
-                Test::assert_eq(&3500.0, &l2.round(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.round(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.round(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.round(kilometer).get(kilometer));
-                Test::assert_eq(&4.0, &l4.round(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.round(kilogram).get(kilogram));
-                Test::assert_eq(&4.0, &m2.round(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3300.0, &l1.round::<meter>().get::<meter>());
+                Test::assert_eq(&4.0, &l2.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3500.0, &l2.round::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.round::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.round::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&4.0, &l4.round::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.round::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&4.0, &m2.round::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -1219,16 +1219,16 @@ mod quantities_macro {
                 let m1 = k::Mass::new::<kilogram>(3.3);
                 let m2 = k::Mass::new::<kilogram>(3.5);
 
-                Test::assert_eq(&3.0, &l1.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3300.0, &l1.trunc(meter).get(meter));
-                Test::assert_eq(&3.0, &l2.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3500.0, &l2.trunc(meter).get(meter));
-                Test::assert_eq(&0.0, &l3.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l3.trunc(meter).get(meter));
-                Test::assert_eq(&0.0, &l4.trunc(kilometer).get(kilometer));
-                Test::assert_eq(&3.0, &l4.trunc(meter).get(meter));
-                Test::assert_eq(&3.0, &m1.trunc(kilogram).get(kilogram));
-                Test::assert_eq(&3.0, &m2.trunc(kilogram).get(kilogram));
+                Test::assert_eq(&3.0, &l1.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3300.0, &l1.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &l2.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3500.0, &l2.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l3.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l3.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&0.0, &l4.trunc::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&3.0, &l4.trunc::<meter>().get::<meter>());
+                Test::assert_eq(&3.0, &m1.trunc::<kilogram>().get::<kilogram>());
+                Test::assert_eq(&3.0, &m2.trunc::<kilogram>().get::<kilogram>());
             }
 
             #[test]
@@ -1237,19 +1237,19 @@ mod quantities_macro {
                 let l2 = k::Length::new::<meter>(3.3);
                 let m1 = k::Mass::new::<kilogram>(3.3);
 
-                Test::assert_eq(&3.3.fract(), &l1.fract(kilometer).get(kilometer));
-                Test::assert_eq(&(3.3.fract() * 1000.0), &l1.fract(kilometer).get(meter));
+                Test::assert_eq(&3.3.fract(), &l1.fract::<kilometer>().get::<kilometer>());
+                Test::assert_eq(&(3.3.fract() * 1000.0), &l1.fract::<kilometer>().get::<meter>());
                 Test::assert_eq(&((3.3 * 1000.0).fract() / 1000.0),
-                    &l1.fract(meter).get(kilometer));
-                Test::assert_eq(&(3.3 * 1000.0).fract(), &l1.fract(meter).get(meter));
+                    &l1.fract::<meter>().get::<kilometer>());
+                Test::assert_eq(&(3.3 * 1000.0).fract(), &l1.fract::<meter>().get::<meter>());
 
-                Test::assert_eq(&(3.3 / 1000.0).fract(), &l2.fract(kilometer).get(kilometer));
+                Test::assert_eq(&(3.3 / 1000.0).fract(), &l2.fract::<kilometer>().get::<kilometer>());
                 Test::assert_eq(&((3.3 / 1000.0).fract() * 1000.0),
-                    &l2.fract(kilometer).get(meter));
-                Test::assert_eq(&(3.3.fract() / 1000.0), &l2.fract(meter).get(kilometer));
-                Test::assert_eq(&3.3.fract(), &l2.fract(meter).get(meter));
+                    &l2.fract::<kilometer>().get::<meter>());
+                Test::assert_eq(&(3.3.fract() / 1000.0), &l2.fract::<meter>().get::<kilometer>());
+                Test::assert_eq(&3.3.fract(), &l2.fract::<meter>().get::<meter>());
 
-                Test::assert_eq(&3.3.fract(), &m1.fract(kilogram).get(kilogram));
+                Test::assert_eq(&3.3.fract(), &m1.fract::<kilogram>().get::<kilogram>());
             }
         }
     }


### PR DESCRIPTION
`_unit` parameter already removed from `new()` and provides no benefit
or utility as only the type is important and must be statically known at
compile time.

---

Breaking change. I'm reviewing further breaking changes as currently there is no way for unit selection to be done based on user input.