### PR TITLE
Add format tools for quantities.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,20 @@ storage_types! {
     }
 }
 
+/// Utilities for formatting and printing quantities.
+pub mod fmt {
+    /// An enum to specify the display style to use.
+    #[derive(Clone, Copy, Debug)]
+    pub enum DisplayStyle {
+        /// Display the value and a unit abbreviation, e.g. "1.0 m", "327 s".
+        Abbreviation,
+
+        /// Display the value and full unit name (pluralized as appropriate),
+        /// e.g. "1 kilogram", "756 feet".
+        Description,
+    }
+}
+
 /// Unicode string slice manipulation for quantities.
 pub mod str {
     /// Represents an error encountered while parsing a string into a `Quantity`.

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -296,6 +296,102 @@ macro_rules! quantity {
             {
                 Self::new::<N>(self.get::<N>().fract())
             }
+
+            /// Creates a struct that can be used to format a compatible quantity for display.
+            ///
+            /// # Notes
+            /// The return value of this method cannot be used to print directly, but is instead
+            /// used to format quantities and can be reused; see
+            /// [Arguments::with](../fmt/struct.Arguments.html#method.with) and the examples below.
+            ///
+            /// If you do not need to format multiple quantities, consider using
+            /// [`to_format_args`](#method.to_format_args) instead.
+            ///
+            /// # Examples
+            #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+            #[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+            /// # use uom::si::f32::*;
+            /// # use uom::si::time::{femtosecond, picosecond};
+            /// # use uom::si::fmt::Arguments;
+            /// # use uom::fmt::DisplayStyle::*;
+            /// let t = Time::new::<picosecond>(1.0_E-1);
+            /// let a = Time::format_args(femtosecond, Description);
+            ///
+            /// assert_eq!("100 femtoseconds", format!("{}", a.with(t)));
+            /// ```
+            pub fn format_args<N>(
+                unit: N,
+                style: $crate::fmt::DisplayStyle
+            ) -> super::fmt::Arguments<Dimension, N>
+            where
+                N: Unit
+            {
+                super::fmt::Arguments {
+                    dimension: $crate::lib::marker::PhantomData,
+                    unit: unit,
+                    style: style,
+                }
+            }
+
+            /// Creates a struct that formats `self` for display.
+            ///
+            /// # Notes
+            /// Unlike [`format_args`](#method.format_args), the return value of this method *can*
+            /// be used directly for display. It will format the (cloned) value of `self` for the
+            /// quantity on which it is called **and nothing else**.
+            ///
+            /// If you wish to reuse the return value to format multiple quantities, use
+            /// [`format_args`](#method.format_args) instead.
+            ///
+            /// # Examples
+            #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+            #[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+            /// # use uom::si::f32::*;
+            /// # use uom::si::time::{femtosecond, picosecond};
+            /// # use uom::si::fmt::Arguments;
+            /// # use uom::fmt::DisplayStyle::*;
+            /// let t = Time::new::<picosecond>(1.0_E-1);
+            /// let a = t.to_format_args(femtosecond, Description);
+            ///
+            /// assert_eq!("100 femtoseconds", format!("{}", a));
+            /// ```
+            pub fn to_format_args<N>(
+                self,
+                unit: N,
+                style: $crate::fmt::DisplayStyle
+            ) -> super::fmt::QuantityArguments<Dimension, U, V, N>
+            where
+                N: Unit
+            {
+                super::fmt::QuantityArguments {
+                    arguments: super::fmt::Arguments {
+                        dimension: $crate::lib::marker::PhantomData,
+                        unit: unit,
+                        style: style,
+                    },
+                    quantity: self,
+                }
+            }
+        }
+
+        impl<N> super::fmt::Arguments<Dimension, N>
+        where
+            N: super::Unit + Unit,
+        {
+            /// Specifies a quantity to display.
+            pub fn with<U, V>(
+                self,
+                quantity: $quantity<U, V>
+            ) -> super::fmt::QuantityArguments<Dimension, U, V, N>
+            where
+                U: super::Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V>,
+            {
+                super::fmt::QuantityArguments {
+                    arguments: self,
+                    quantity: quantity,
+                }
+            }
         }
 
         mod str {

--- a/src/system.rs
+++ b/src/system.rs
@@ -169,7 +169,7 @@ macro_rules! system {
         /// # use uom::si::f32::*;
         /// # use uom::si::length::meter;
         /// // Create a length of 1 meter.
-        /// let L = Length::new::<meter>(1.0);
+        /// let l = Length::new::<meter>(1.0);
         /// ```
         ///
         /// `Quantity` fields are public to allow for the creation of `const` values and instances
@@ -1198,6 +1198,157 @@ macro_rules! system {
                     value,
                 })
             }
+        }
+
+        /// Utilities for formatting and printing quantities.
+        pub mod fmt {
+            use $crate::lib::fmt;
+            use super::{Dimension, Quantity, Unit, Units, from_base};
+            use $crate::num::Num;
+            use $crate::Conversion;
+            use $crate::fmt::DisplayStyle;
+
+            /// A struct to specify a display style and unit.
+            ///
+            /// # Usage
+            /// ## Indirect style
+            #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+            #[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+            /// # use uom::si::f32::*;
+            /// # use uom::si::length::{centimeter, meter};
+            /// # use uom::si::fmt::Arguments;
+            /// # use uom::fmt::DisplayStyle::*;
+            /// let l = Length::new::<meter>(1.0);
+            /// let a = Length::format_args(centimeter, Description);
+            ///
+            /// assert_eq!("100 centimeters", format!("{}", a.with(l)));
+            /// ```
+            ///
+            /// ## Direct style
+            #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+            #[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+            /// # use uom::si::f32::*;
+            /// # use uom::si::length::{centimeter, meter};
+            /// # use uom::si::fmt::Arguments;
+            /// # use uom::fmt::DisplayStyle::*;
+            /// let l = Length::new::<meter>(1.0);
+            /// let a = l.to_format_args(centimeter, Description);
+            ///
+            /// assert_eq!("100 centimeters", format!("{}", a));
+            /// ```
+            #[allow(missing_debug_implementations)] // Prevent accidental direct use.
+            pub struct Arguments<D, N>
+            where
+                D: Dimension + ?Sized,
+                N: Unit,
+            {
+                pub(super) dimension: $crate::lib::marker::PhantomData<D>,
+                pub(super) unit: N,
+                pub(super) style: DisplayStyle,
+            }
+
+            impl<D, N> $crate::lib::clone::Clone for Arguments<D, N>
+            where
+                D: Dimension + ?Sized,
+                N: Unit,
+            {
+                fn clone(&self) -> Self {
+                    Self {
+                        dimension: $crate::lib::marker::PhantomData,
+                        unit: self.unit.clone(),
+                        style: self.style.clone()
+                    }
+                }
+            }
+
+            impl<D, N> $crate::lib::marker::Copy for Arguments<D, N>
+            where
+                D: Dimension + ?Sized,
+                N: Unit,
+            {
+            }
+
+            /// A struct to specify a display style and unit for a given quantity.
+            ///
+            #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+            #[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+            /// # use uom::si::f32::*;
+            /// # use uom::si::length::{centimeter, meter};
+            /// # use uom::si::fmt::Arguments;
+            /// # use uom::fmt::DisplayStyle::*;
+            /// let l = Length::new::<meter>(1.0);
+            /// let a = l.to_format_args(centimeter, Description);
+            ///
+            /// assert_eq!("100 centimeters", format!("{}", a));
+            /// ```
+            pub struct QuantityArguments<D, U, V, N>
+            where
+                D: Dimension + ?Sized,
+                U: Units<V> + ?Sized,
+                V: Num + Conversion<V>,
+                N: Unit,
+            {
+                pub(super) arguments: Arguments<D, N>,
+                pub(super) quantity: Quantity<D, U, V>,
+            }
+
+            impl<D, U, V, N> $crate::lib::clone::Clone for QuantityArguments<D, U, V, N>
+            where
+                D: Dimension + ?Sized,
+                U: Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::clone::Clone,
+                N: Unit,
+            {
+                fn clone(&self) -> Self {
+                    Self {
+                        arguments: self.arguments.clone(),
+                        quantity: self.quantity.clone()
+                    }
+                }
+            }
+
+            impl<D, U, V, N> $crate::lib::marker::Copy for QuantityArguments<D, U, V, N>
+            where
+                D: Dimension + ?Sized,
+                U: Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::marker::Copy,
+                N: Unit,
+            {
+            }
+
+            macro_rules! format_arguments {
+                ($style:ident) => {
+                    impl<D, U, V, N> fmt::$style for QuantityArguments<D, U, V, N>
+                    where
+                        D: Dimension + ?Sized,
+                        U: Units<V> + ?Sized,
+                        V: Num + Conversion<V> + fmt::$style,
+                        N: Unit + Conversion<V, T = V::T>,
+                    {
+                        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                            let value = from_base::<D, U, V, N>(&self.quantity.value);
+
+                            value.fmt(f)?;
+                            write!(f, " {}",
+                                match self.arguments.style {
+                                    DisplayStyle::Abbreviation => N::abbreviation(),
+                                    DisplayStyle::Description => {
+                                        if value.is_one() { N::singular() } else { N::plural() }
+                                    },
+                                })
+                        }
+                    }
+                };
+            }
+
+            format_arguments!(Binary);
+            format_arguments!(Debug);
+            format_arguments!(Display);
+            format_arguments!(LowerExp);
+            format_arguments!(LowerHex);
+            format_arguments!(Octal);
+            format_arguments!(UpperExp);
+            format_arguments!(UpperHex);
         }
 
         /// Macro to implement [`quantity`](si/struct.Quantity.html) type aliases for a specific

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -1,5 +1,12 @@
 //! Static assertions.
 
+use tests::*;
+
+assert_impl!(arguments; Arguments<Q<P1, Z0>, meter>,
+    Clone, Copy);
+assert_impl!(display_style; ::fmt::DisplayStyle,
+    Clone, Copy);
+
 storage_types! {
     types: Float;
 
@@ -7,6 +14,8 @@ storage_types! {
 
     assert_impl!(q; Quantity<Q<Z0, Z0>, U<V>, V>,
         Clone, Copy, PartialEq, PartialOrd, Send, Sync);
+    assert_impl!(quantity_arguments; QuantityArguments<Q<P1, Z0>, U<V>, V, meter>,
+        Clone, Copy);
 }
 
 storage_types! {
@@ -16,6 +25,8 @@ storage_types! {
 
     assert_impl!(q; Quantity<Q<Z0, Z0>, U<V>, V>,
         Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Send, Sync, ::lib::hash::Hash);
+    assert_impl!(quantity_arguments; QuantityArguments<Q<P1, Z0>, U<V>, V, meter>,
+        Clone, Copy);
 }
 
 storage_types! {
@@ -25,4 +36,6 @@ storage_types! {
 
     assert_impl!(q; Quantity<Q<Z0, Z0>, U<V>, V>,
         Clone, Eq, Ord, PartialEq, PartialOrd, Send, Sync, ::lib::hash::Hash);
+    assert_impl!(quantity_arguments; QuantityArguments<Q<P1, Z0>, U<V>, V, meter>,
+        Clone);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Tests for `uom` macros.
 
+use self::fmt::{Arguments, QuantityArguments};
 use self::length::{kilometer, meter};
 use self::mass::kilogram;
 use lib::fmt::Debug;

--- a/src/tests/quantity.rs
+++ b/src/tests/quantity.rs
@@ -1,5 +1,112 @@
 //! Tests for the `quantity!` macro.
 
+mod fmt {
+    storage_types! {
+        use tests::*;
+
+        mod f { Q!(tests, super::V); }
+
+        macro_rules! test_fmt_symbol {
+            ($st:expr, $_v:ty) => (
+                macro_rules! test_fmt_flag {
+                    ($s:expr, $v:ty) => (
+                        let v = <$v as ::num::One>::one();
+                        let style = ::fmt::DisplayStyle::Description;
+                        let m = f::Mass::new::<kilogram>(v.clone());
+                        assert_eq!(format!(concat!($s, " kilogram"), v),
+                            format!($s, m.to_format_args(kilogram, style)));
+                        let l = f::Length::new::<meter>(v.clone());
+                        assert_eq!(format!(concat!($s, " meter"), v),
+                            format!($s, l.to_format_args(meter, style)));
+                    )
+                }
+                test_fmt_flag!(concat!("{:", $st, "}"), $_v);
+                test_fmt_flag!(concat!("{:+", $st, "}"), $_v);
+                test_fmt_flag!(concat!("{:05", $st, "}"), $_v);
+            )
+        }
+
+        #[test]
+        fn display() {
+            test_fmt_symbol!("", V);
+        }
+
+        #[test]
+        fn debug() {
+            test_fmt_symbol!("?", V);
+        }
+    }
+
+    mod float {
+        storage_types! {
+            types: Float;
+
+            use tests::*;
+
+            mod f { Q!(tests, super::V); }
+
+            #[test]
+            fn round_trip() {
+                let l = f::Length::new::<meter>(V::one());
+                let s1 = &format!("{}", l.to_format_args(kilometer, ::fmt::DisplayStyle::Abbreviation));
+                assert_eq!(s1.parse::<f::Length>(), Ok(l));
+                let s2 = &format!("{}", l.to_format_args(meter, ::fmt::DisplayStyle::Abbreviation));
+                assert_eq!(s2.parse::<f::Length>(), Ok(l));
+            }
+        }
+    }
+
+    mod int {
+        storage_types! {
+            types: PrimInt;
+
+            use tests::*;
+
+            mod f { Q!(tests, super::V); }
+
+            macro_rules! test_fmt_symbol {
+                ($st:expr, $_v:ty) => (
+                    macro_rules! test_fmt_flag {
+                        ($s:expr, $v:ty) => (
+                            let v = <$v as ::num::One>::one();
+                            let style = ::fmt::DisplayStyle::Description;
+                            let m = f::Mass::new::<kilogram>(v);
+                            assert_eq!(format!(concat!($s, " kilogram"), v),
+                                format!($s, m.to_format_args(kilogram, style)));
+                            let l = f::Length::new::<meter>(v);
+                            assert_eq!(format!(concat!($s, " meter"), v),
+                                format!($s, l.to_format_args(meter, style)));
+                        )
+                    }
+                    test_fmt_flag!(concat!("{:", $st, "}"), $_v);
+                    test_fmt_flag!(concat!("{:+", $st, "}"), $_v);
+                    test_fmt_flag!(concat!("{:05", $st, "}"), $_v);
+                )
+            }
+
+            #[test]
+            fn octal() {
+                test_fmt_symbol!("o", V);
+            }
+
+            #[test]
+            fn lower_hex() {
+                test_fmt_symbol!("x", V);
+            }
+
+            #[test]
+            fn upper_hex() {
+                test_fmt_symbol!("X", V);
+            }
+
+            #[test]
+            fn binary() {
+                test_fmt_symbol!("b", V);
+            }
+        }
+    }
+}
+
 #[cfg(feature = "autoconvert")]
 storage_types! {
     use tests::*;


### PR DESCRIPTION
I can't reopen #73 because I force-pushed (oops), but let's reopen this thing!

Changes I've made:
- Renamed `display_arguments!` to `format_arguments!` (closer to `fmt`).
  - I'm not a huge fan of the similarity to `format_args!`, but I couldn't come up with anything better.
- Changed `pub(crate)` to `pub(super)` in `{Quantity,}Arguments` members.
- Wrote some doc comments and notes (they're at least better than "asdf," if only just).
- Added examples to `format_args` and `to_format_args` (decided to keep the consolidated example for easier comparison).
- Manually implemented `Clone` and `Copy` for `{Quantity,}Arguments`.
  - It seems like this shouldn't be necessary, but I wasn't able to derive either trait for either struct, despite trait bounds matching exactly; I may try to isolate this and report it upstream.
- Added `assert_impl!` tests for `Clone` and `Copy` on `{Quantity,}Arguments`.
- Added `round_trip` test.
- Added tests for `Display` and `Debug` with a couple of extra modifiers.
  - I tried to add more, but there's some weirdness with `storage_types!` that kept me from using other types (to use storage types that implement `Binary`, for example).
  - I'm not really happy with the current version of this, but it's a start.

Edit: The build is failing because I didn't enable all the relevant things when testing locally; I'll fix it when I have some time.