### PR TITLE
Add prefixes for watt-hours and ampere-hours

### DIFF
--- a/src/si/electric_charge.rs
+++ b/src/si/electric_charge.rs
@@ -36,8 +36,18 @@ quantity! {
         @zeptocoulomb: prefix!(zepto); "zC", "zeptocoulomb", "zeptocoulombs";
         @yoctocoulomb: prefix!(yocto); "yC", "yoctocoulomb", "yoctocoulombs";
 
-        @abcoulomb: 1.0_E1; "abC", "abcoulomb", "abcoulombs";
+        @petaampere_hour: 3.6_E18; "PA · h", "petaampere hour", "petaampere hours";
+        @teraampere_hour: 3.6_E15; "TA · h", "teraampere hour", "teraampere hours";
+        @gigaampere_hour: 3.6_E12; "GA · h", "gigaampere hour", "gigaampere hours";
+        @megaampere_hour: 3.6_E9; "MA · h", "megaampere hour", "megaampere hours";
+        @kiloampere_hour: 3.6_E6; "kA · h", "kiloampere hour", "kiloampere hours";
+        @hectoampere_hour: 3.6_E5; "hA · h", "hectoampere hour", "hectoampere hours";
+        @decaampere_hour: 3.6_E4; "daA · h", "decaampere hour", "decaampere hours";
         @ampere_hour: 3.6_E3; "A · h", "ampere hour", "ampere hours";
+        @milliampere_hour: 3.6_E0; "mA · h", "milliampere hour", "milliampere hours";
+        @microampere_hour: 3.6_E-3; "µA · h", "microampere hour", "microampere hours";
+
+        @abcoulomb: 1.0_E1; "abC", "abcoulomb", "abcoulombs";
         @faraday: 9.648_531_E4; "F", "faraday", "faradays";
         @franklin: 3.335_641_E-10; "Fr", "franklin", "franklins";
         @statcoulomb: 3.335_641_E-10; "statC", "statcoulomb", "statcoulombs";

--- a/src/si/energy.rs
+++ b/src/si/energy.rs
@@ -36,6 +36,17 @@ quantity! {
         @zeptojoule: prefix!(zepto); "zJ", "zeptojoule", "zeptojoules";
         @yoctojoule: prefix!(yocto); "yJ", "yoctojoule", "yoctojoules";
 
+        @petawatt_hour: 3.6_E18; "PW · h", "petawatt hour", "petawatt hours";
+        @terawatt_hour: 3.6_E15; "TW · h", "terawatt hour", "terawatt hours";
+        @gigawatt_hour: 3.6_E12; "GW · h", "gigawatt hour", "gigawatt hours";
+        @megawatt_hour: 3.6_E9; "MW · h", "megawatt hour", "megawatt hours";
+        @kilowatt_hour: 3.6_E6; "kW · h", "kilowatt hour", "kilowatt hours";
+        @hectowatt_hour: 3.6_E5; "hW · h", "hectowatt hour", "hectowatt hours";
+        @decawatt_hour: 3.6_E4; "daW · h", "decawatt hour", "decawatt hours";
+        @watt_hour: 3.6_E3; "W · h", "watt hour", "watt hours";
+        @milliwatt_hour: 3.6_E0; "mW · h", "milliwatt hour", "milliwatt hours";
+        @microwatt_hour: 3.6_E-3; "µW · h", "microwatt hour", "microwatt hours";
+
         @btu_it: 1.055_056_E3; "Btu (IT)", "British thermal unit (IT)",
             "British thermal units (IT)";
         @btu: 1.054_350_E3; "Btu", "British thermal unit", "British thermal units";
@@ -58,12 +69,10 @@ quantity! {
             "foot pounds-force"; // @foot_pound_force
         @kilocalorie_it: 4.186_8_E3; "kcal (IT)", "kilocalorie (IT)", "kilocalories (IT)";
         @kilocalorie: 4.184_E3; "kcal", "kilocalorie", "kilocalories";
-        @kilowatt_hour: 3.6_E6; "kW · h", "kilowatt hour", "kilowatt hours";
         @quad: 1.055_056_E18; "10¹⁵ Btu (IT)", "quad", "quads";
         @therm_ec: 1.055_06_E8; "thm (EC)", "therm (EC)", "therms (EC)";
         @therm_us: 1.054_804_E8; "thm", "therm", "therms";
         @ton_tnt: 4.184_E9; "t of TNT", "ton of TNT", "tons of TNT";
-        @watt_hour: 3.6_E3; "W · h", "watt hour", "watt hours";
         @watt_second: 1.0_E0; "W · s", "watt second", "watt seconds";
     }
 }


### PR DESCRIPTION
Hey, @iliekturtles !

I'm integrating `uom` into the [battery](https://github.com/svartalf/rust-battery/tree/units) crate and there are few prefixes for `watt-hours` and `ampere-hours` that I really could use but there are missing.

Not quite sure if it is worth to add prefixes smaller than micro- though. Any thoughts?