### PR TITLE
Correct macros to generate valid 2015/2018 edition code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ matrix:
     script: |
       set -e
       cargo test --verbose --features "use_serde"
-      cargo test --manifest-path tests/feature_check/Cargo.toml --verbose
+      cargo test -p feature_check --verbose --features "use_serde"
+      cargo test -p edition_check --verbose --features "use_serde"
       cargo test --verbose --no-default-features --features "autoconvert f32 f64 si use_serde"
       cargo test --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 isize i8 i16 i32 i64 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde"
   - name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ maintenance = { status = "actively-developed" }
 [workspace]
 members = [
     "uom-macros",
+    "tests/edition_check",
     "tests/feature_check",
 ]
 

--- a/examples/mks.rs
+++ b/examples/mks.rs
@@ -81,9 +81,9 @@ system! {
 }
 
 mod f32 {
-    mod s {
-        pub use *;
+    mod mks {
+        pub use super::super::*;
     }
 
-    Q!(f32::s, f32);
+    Q!(self::mks, f32);
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1455,7 +1455,13 @@ macro_rules! system {
         /// #         }
         /// #     }
         /// mod f32 {
-        ///     Q!(mks, f32/*, (centimeter, gram, second)*/);
+        ///     mod mks {
+        ///         pub use super::super::*;
+        ///     }
+        ///
+        ///     // `crate::mks` works in Rust 1.30.0 or later. `mod mks {...}` workaround is needed
+        ///     // to support older versions of Rust and the 2018 edition at the same time.
+        ///     Q!(self::mks, f32/*, (centimeter, gram, second)*/);
         /// }
         /// # }
         /// ```

--- a/tests/edition_check/Cargo.toml
+++ b/tests/edition_check/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "feature_check"
+name = "edition_check"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 uom = { path = "../.." }

--- a/tests/edition_check/src/lib.rs
+++ b/tests/edition_check/src/lib.rs
@@ -1,0 +1,63 @@
+//! Validate that the `system!`, `quantity!`, and `$quantities!` macros generate valid code for the
+//! 2018 edition.
+
+#[macro_use]
+extern crate uom;
+
+mod mks {
+    mod length {
+        quantity! {
+            /// Length (base unit meter, m<sup>1</sup>).
+            quantity: Length; "length";
+            /// Length dimension, m<sup>1</sup>.
+            dimension: Q<P1 /*length*/, Z0 /*mass*/, Z0 /*time*/>;
+            units {
+                @meter: 1.0E0; "m", "meter", "meters";
+                @foot: 3.048E-1; "ft", "foot", "feet";
+            }
+        }
+    }
+
+    mod mass {
+        quantity! {
+            /// Mass (base unit kilogram, kg<sup>1</sup>).
+            quantity: Mass; "mass";
+            /// Mass dimension, kg<sup>1</sup>.
+            dimension: Q<Z0 /*length*/, P1 /*mass*/, Z0 /*time*/>;
+            units {
+                @kilogram: 1.0; "kg", "kilogram", "kilograms";
+            }
+        }
+    }
+
+    mod time {
+        quantity! {
+            /// Time (base unit second, s<sup>1</sup>).
+            quantity: Time; "time";
+            /// Time dimension, s<sup>1</sup>.
+            dimension: Q<Z0 /*length*/, Z0 /*mass*/, P1 /*time*/>;
+            units {
+                @second: 1.0; "s", "second", "seconds";
+            }
+        }
+    }
+
+    system! {
+        /// System of quantities, Q.
+        quantities: Q {
+            length: meter, L;
+            mass: kilogram, M;
+            time: second, T;
+        }
+        /// System of units, U.
+        units: U {
+            mod length::Length,
+            mod mass::Mass,
+            mod time::Time,
+        }
+    }
+
+    mod f32 {
+        Q!(crate::mks, f32 /*, (centimeter, gram, second)*/);
+    }
+}

--- a/tests/feature_check/src/lib.rs
+++ b/tests/feature_check/src/lib.rs
@@ -42,9 +42,11 @@
 //! }
 //!
 //! mod f32 {
-//!     mod s { pub use *; }
+//!     mod m {
+//!         pub use super::super::*;
+//!     }
 //!
-//!     Q!(f32::s, f32);
+//!     Q!(self::m, f32);
 //! }
 //!
 //! fn main() {


### PR DESCRIPTION
Doc test on the `$quantities!` macro would fail with the error `no
``mks`` external crate` when the `system!` macro was invoked in a crate
using the 2018 edition. All invocations of the `$quantities!` macro are
corrected and a new test crate, `edition_check`, is added to validate
`uom` can be used in 2018 edition code. Resolves #119.

@svartalf if you could review that would be great.