### PR TITLE
added torque as an alias of energy

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -320,6 +320,26 @@ macro_rules! quantity {
             }
         }
 
+        impl<N> super::fmt::Arguments<Dimension, N>
+        where
+            N: super::Unit + Unit,
+        {
+            /// Specifies a quantity to display.
+            pub fn with<U, V>(
+                self,
+                quantity: $quantity<U, V>
+            ) -> super::fmt::QuantityArguments<Dimension, U, V, N>
+            where
+                U: super::Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V>,
+            {
+                super::fmt::QuantityArguments {
+                    arguments: self,
+                    quantity: quantity,
+                }
+            }
+        }
+
         mod str {
             storage_types! {
                 use $crate::lib::str::FromStr;
@@ -526,26 +546,6 @@ macro_rules! quantity {
         #[inline(always)]
         pub fn description() -> &'static str {
             $description
-        }
-
-        impl<N> super::fmt::Arguments<Dimension, N>
-        where
-            N: super::Unit + Unit,
-        {
-            /// Specifies a quantity to display.
-            pub fn with<U, V>(
-                self,
-                quantity: $quantity<U, V>
-            ) -> super::fmt::QuantityArguments<Dimension, U, V, N>
-            where
-                U: super::Units<V> + ?Sized,
-                V: $crate::num::Num + $crate::Conversion<V>,
-            {
-                super::fmt::QuantityArguments {
-                    arguments: self,
-                    quantity: quantity,
-                }
-            }
         }
     };
     (@unit $(#[$unit_attr:meta])+ @$unit:ident) => {

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -49,7 +49,7 @@ system! {
         temperature_interval::TemperatureInterval,
         thermodynamic_temperature::ThermodynamicTemperature,
         time::Time,
-        torque_magnitude::TorqueMagnitude,
+        torque::Torque,
         velocity::Velocity,
         volume::Volume,
         volume_rate::VolumeRate,

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -49,6 +49,7 @@ system! {
         temperature_interval::TemperatureInterval,
         thermodynamic_temperature::ThermodynamicTemperature,
         time::Time,
+        torque_magnitude::TorqueMagnitude,
         velocity::Velocity,
         volume::Volume,
         volume_rate::VolumeRate,

--- a/src/si/torque.rs
+++ b/src/si/torque.rs
@@ -4,11 +4,11 @@ quantity! {
     /// Torque magnitude (base unit newton meter, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>).
     ///
     /// Torques are moments, which means they inherently depend on a distance to a frame of
-    /// reference.  If instead you talk about the magnitude of the torque about some point you can
+    /// reference. If instead you talk about the magnitude of the torque about some point you can
     /// externalize the frame of reference for the sake of fitting torques into a framework of
-    /// quantities and dimensional analysis.  Note that as a consequence of this the compile time
+    /// quantities and dimensional analysis. Note that as a consequence of this the compile time
     /// guarantees of this library are weaker for torques than other quantities; it is very possible
-    /// to combine torques in nonsensical ways and still have your code typecheck.  Be careful.
+    /// to combine torques in nonsensical ways and still have your code typecheck. Be careful.
     quantity: Torque; "Torque";
     alias_of: energy; // This is an alias due to its being dimensionally equivalent to energy.
     /// Torque dimension, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>.

--- a/src/si/torque.rs
+++ b/src/si/torque.rs
@@ -1,16 +1,15 @@
-//! Torque (aka moment of force) (base unit newton meter, kg<sup>1</sup> · m<sup>2</sup> ·
-//! s<sup>-2</sup>).
+//! Torque (aka moment of force) (base unit newton meter, m<sup>2</sup> · kg · s<sup>-2</sup>).
 
 quantity! {
     /// Torque magnitude (base unit newton meter, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>).
     ///
-    /// Torques are moments, by which I mean they inherently depend on a distance to a frame of
-    /// reference.  If instead we talk about the magnitude of the torque about some point we can
+    /// Torques are moments, which means they inherently depend on a distance to a frame of
+    /// reference.  If instead you talk about the magnitude of the torque about some point you can
     /// externalize the frame of reference for the sake of fitting torques into a framework of
     /// quantities and dimensional analysis.  Note that as a consequence of this the compile time
     /// guarantees of this library are weaker for torques than other quantities; it is very possible
     /// to combine torques in nonsensical ways and still have your code typecheck.  Be careful.
-    quantity: TorqueMagnitude; "Torque";
+    quantity: Torque; "Torque";
     alias_of: energy; // This is an alias due to its being dimensionally equivalent to energy.
     /// Torque dimension, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>.
     dimension: ISQ<
@@ -66,7 +65,6 @@ quantity! {
         @newton_zeptometer: prefix!(zepto); "N · zm", "newton zeptometer", "newton zeptometers";
         @newton_yoctometer: prefix!(yocto); "N · ym", "newton yoctometer", "newton yoctometers";
 
-
         @dyne_meter: 1.0_E-5; "dyn · m", "dyne meter", "dyne meters";
         @dyne_centimeter: 1.0_E-7; "dyn · cm", "dyne centimeter", "dyne centimeters";
         @kilogram_force_meter: 9.806_65_E0; "kgf · m", "kilogram-force meter",
@@ -77,7 +75,6 @@ quantity! {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     storage_types! {
@@ -85,12 +82,12 @@ mod tests {
         use si::quantities::*;
         use si::force as f;
         use si::length as l;
-        use si::torque_magnitude as t;
+        use si::torque as t;
         use tests::Test;
 
         #[test]
         fn check_dimension() {
-            let _: TorqueMagnitude<V> = Force::new::<f::newton>(V::one())
+            let _: Torque<V> = Force::new::<f::newton>(V::one())
                 * Length::new::<l::meter>(V::one());
         }
 
@@ -147,7 +144,7 @@ mod tests {
             test::<f::pound_force, l::inch, t::pound_force_inch>();
 
             fn test<F: f::Conversion<V>, L: l::Conversion<V>, T: t::Conversion<V>>() {
-                Test::assert_approx_eq(&TorqueMagnitude::new::<T>(V::one()),
+                Test::assert_approx_eq(&Torque::new::<T>(V::one()),
                     &(Force::new::<F>(V::one()) * Length::new::<L>(V::one())));
             }
         }

--- a/src/si/torque_magnitude.rs
+++ b/src/si/torque_magnitude.rs
@@ -8,8 +8,8 @@ quantity! {
     /// reference.  If instead we talk about the magnitude of the torque about some point we can
     /// externalize the frame of reference for the sake of fitting torques into a framework of
     /// quantities and dimensional analysis.  Note that as a consequence of this the compile time
-    /// guarantees of this library are weaker for torques than other units; it is very possible to
-    /// combine torques in nonsensical ways and still have your code typecheck.  Be careful.
+    /// guarantees of this library are weaker for torques than other quantities; it is very possible
+    /// to combine torques in nonsensical ways and still have your code typecheck.  Be careful.
     quantity: TorqueMagnitude; "Torque";
     alias_of: energy; // This is an alias due to its being dimensionally equivalent to energy.
     /// Torque dimension, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>.
@@ -69,6 +69,8 @@ quantity! {
 
         @dyne_meter: 1.0_E-5; "dyn · m", "dyne meter", "dyne meters";
         @dyne_centimeter: 1.0_E-7; "dyn · cm", "dyne centimeter", "dyne centimeters";
+        @kilogram_force_meter: 9.806_65_E0; "kgf · m", "kilogram-force meter",
+            "kilogram-force meters";
         @ounce_force_inch: 7.061_553_06_E-3; "ozf · in", "ounce-force inch", "ounces-force inches";
         @pound_force_foot: 1.355_818_065_6_E0; "lbf · ft", "pound-force foot", "pounds-force feet";
         @pound_force_inch: 1.129_848_388_E-1; "lbf · in", "pound-force inch", "pounds-force inches";
@@ -139,6 +141,7 @@ mod tests {
 
             test::<f::dyne, l::meter, t::dyne_meter>();
             test::<f::dyne, l::centimeter, t::dyne_centimeter>();
+            test::<f::kilogram_force, l::meter, t::kilogram_force_meter>();
             test::<f::ounce_force, l::inch, t::ounce_force_inch>();
             test::<f::pound_force, l::foot, t::pound_force_foot>();
             test::<f::pound_force, l::inch, t::pound_force_inch>();

--- a/src/si/torque_magnitude.rs
+++ b/src/si/torque_magnitude.rs
@@ -1,0 +1,152 @@
+//! Torque (aka moment of force) (base unit newton meter, kg<sup>1</sup> · m<sup>2</sup> ·
+//! s<sup>-2</sup>).
+
+quantity! {
+    /// Torque magnitude (base unit newton meter, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>).
+    ///
+    /// Torques are moments, by which I mean they inherently depend on a distance to a frame of
+    /// reference.  If instead we talk about the magnitude of the torque about some point we can
+    /// externalize the frame of reference for the sake of fitting torques into a framework of
+    /// quantities and dimensional analysis.  Note that as a consequence of this the compile time
+    /// guarantees of this library are weaker for torques than other units; it is very possible to
+    /// combine torques in nonsensical ways and still have your code typecheck.  Be careful.
+    quantity: TorqueMagnitude; "Torque";
+    alias_of: energy; // This is an alias due to its being dimensionally equivalent to energy.
+    /// Torque dimension, kg<sup>1</sup> · m<sup>2</sup> · s<sup>-2</sup>.
+    dimension: ISQ<
+        P2,     // length
+        P1,     // mass
+        N2,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    units {
+        @yottanewton_meter: prefix!(yotta); "YN · m", "yottanewton meter", "yottanewton meters";
+        @zettanewton_meter: prefix!(zetta); "ZN · m", "zettanewton meter", "zettanewton meters";
+        @exanewton_meter: prefix!(exa); "EN · m", "exanewton meter", "exanewton meters";
+        @petanewton_meter: prefix!(peta); "PN · m", "petanewton meter", "petanewton meters";
+        @teranewton_meter: prefix!(tera); "TN · m", "teranewton meter", "teranewton meters";
+        @giganewton_meter: prefix!(giga); "GN · m", "giganewton meter", "giganewton meters";
+        @meganewton_meter: prefix!(mega); "MN · m", "meganewton meter", "meganewton meters";
+        @kilonewton_meter: prefix!(kilo); "kN · m", "kilonewton meter", "kilonewton meters";
+        @hectonewton_meter: prefix!(hecto); "hN · m", "hectonewton meter", "hectonewton meters";
+        @decanewton_meter: prefix!(deca); "daN · m", "decanewton meter", "decanewton meters";
+        /// Derived unit of torque.
+        @newton_meter: prefix!(none); "N · m", "newton meter", "newton meters";
+        @decinewton_meter: prefix!(deci); "dN · m", "decinewton meter", "decinewton meters";
+        @centinewton_meter: prefix!(centi); "cN · m", "centinewton meter", "centinewton meters";
+        @millinewton_meter: prefix!(milli); "mN · m", "millinewton meter", "millinewton meters";
+        @micronewton_meter: prefix!(micro); "µN · m", "micronewton meter", "micronewton meters";
+        @nanonewton_meter: prefix!(nano); "nN · m", "nanonewton meter", "nanonewton meters";
+        @piconewton_meter: prefix!(pico); "pN · m", "piconewton meter", "piconewton meters";
+        @femtonewton_meter: prefix!(femto); "fN · m", "femtonewton meter", "femtonewton meters";
+        @attonewton_meter: prefix!(atto); "aN · m", "attonewton meter", "attonewton meters";
+        @zeptonewton_meter: prefix!(zepto); "zN · m", "zeptonewton meter", "zeptonewton meters";
+        @yoctonewton_meter: prefix!(yocto); "yN · m", "yoctonewton meter", "yoctonewton meters";
+
+        @newton_yottameter: prefix!(yotta); "N · Ym", "newton yottameter", "newton yottameters";
+        @newton_zettameter: prefix!(zetta); "N · Zm", "newton zettameter", "newton zettameters";
+        @newton_exameter: prefix!(exa); "N · Em", "newton exameter", "newton exameters";
+        @newton_petameter: prefix!(peta); "N · Pm", "newton petameter", "newton petameters";
+        @newton_terameter: prefix!(tera); "N · Tm", "newton terameter", "newton terameters";
+        @newton_gigameter: prefix!(giga); "N · Gm", "newton gigameter", "newton gigameters";
+        @newton_megameter: prefix!(mega); "N · Mm", "newton megameter", "newton megameters";
+        @newton_kilometer: prefix!(kilo); "N · km", "newton kilometer", "newton kilometers";
+        @newton_hectometer: prefix!(hecto); "N · hm", "newton hectometer", "newton hectometers";
+        @newton_decameter: prefix!(deca); "N · dam", "newton decameter", "newton decameters";
+        @newton_decimeter: prefix!(deci); "N · dm", "newton decimeter", "newton decimeters";
+        @newton_centimeter: prefix!(centi); "N · cm", "newton centimeter", "newton centimeters";
+        @newton_millimeter: prefix!(milli); "N · mm", "newton millimeter", "newton millimeters";
+        @newton_micrometer: prefix!(micro); "N · µm", "newton micrometer", "newton micrometers";
+        @newton_nanometer: prefix!(nano); "N · nm", "newton nanometer", "newton nanometers";
+        @newton_picometer: prefix!(pico); "N · pm", "newton picometer", "newton picometers";
+        @newton_femtometer: prefix!(femto); "N · fm", "newton femtometer", "newton femtometers";
+        @newton_attometer: prefix!(atto); "N · am", "newton attometer", "newton attometers";
+        @newton_zeptometer: prefix!(zepto); "N · zm", "newton zeptometer", "newton zeptometers";
+        @newton_yoctometer: prefix!(yocto); "N · ym", "newton yoctometer", "newton yoctometers";
+
+
+        @dyne_meter: 1.0_E-5; "dyn · m", "dyne meter", "dyne meters";
+        @dyne_centimeter: 1.0_E-7; "dyn · cm", "dyne centimeter", "dyne centimeters";
+        @ounce_force_inch: 7.061_553_06_E-3; "ozf · in", "ounce-force inch", "ounces-force inches";
+        @pound_force_foot: 1.355_818_065_6_E0; "lbf · ft", "pound-force foot", "pounds-force feet";
+        @pound_force_inch: 1.129_848_388_E-1; "lbf · in", "pound-force inch", "pounds-force inches";
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    storage_types! {
+        use num::One;
+        use si::quantities::*;
+        use si::force as f;
+        use si::length as l;
+        use si::torque_magnitude as t;
+        use tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: TorqueMagnitude<V> = Force::new::<f::newton>(V::one())
+                * Length::new::<l::meter>(V::one());
+        }
+
+        #[test]
+        fn check_units() {
+            test::<f::yottanewton, l::meter, t::yottanewton_meter>();
+            test::<f::zettanewton, l::meter, t::zettanewton_meter>();
+            test::<f::exanewton, l::meter, t::exanewton_meter>();
+            test::<f::petanewton, l::meter, t::petanewton_meter>();
+            test::<f::teranewton, l::meter, t::teranewton_meter>();
+            test::<f::giganewton, l::meter, t::giganewton_meter>();
+            test::<f::meganewton, l::meter, t::meganewton_meter>();
+            test::<f::kilonewton, l::meter, t::kilonewton_meter>();
+            test::<f::hectonewton, l::meter, t::hectonewton_meter>();
+            test::<f::decanewton, l::meter, t::decanewton_meter>();
+            test::<f::newton, l::meter, t::newton_meter>();
+            test::<f::decinewton, l::meter, t::decinewton_meter>();
+            test::<f::centinewton, l::meter, t::centinewton_meter>();
+            test::<f::millinewton, l::meter, t::millinewton_meter>();
+            test::<f::micronewton, l::meter, t::micronewton_meter>();
+            test::<f::nanonewton, l::meter, t::nanonewton_meter>();
+            test::<f::piconewton, l::meter, t::piconewton_meter>();
+            test::<f::femtonewton, l::meter, t::femtonewton_meter>();
+            test::<f::attonewton, l::meter, t::attonewton_meter>();
+            test::<f::zeptonewton, l::meter, t::zeptonewton_meter>();
+            test::<f::yoctonewton, l::meter, t::yoctonewton_meter>();
+
+            test::<f::newton, l::yottameter, t::newton_yottameter>();
+            test::<f::newton, l::zettameter, t::newton_zettameter>();
+            test::<f::newton, l::exameter, t::newton_exameter>();
+            test::<f::newton, l::petameter, t::newton_petameter>();
+            test::<f::newton, l::terameter, t::newton_terameter>();
+            test::<f::newton, l::gigameter, t::newton_gigameter>();
+            test::<f::newton, l::megameter, t::newton_megameter>();
+            test::<f::newton, l::kilometer, t::newton_kilometer>();
+            test::<f::newton, l::hectometer, t::newton_hectometer>();
+            test::<f::newton, l::decameter, t::newton_decameter>();
+            test::<f::newton, l::decimeter, t::newton_decimeter>();
+            test::<f::newton, l::centimeter, t::newton_centimeter>();
+            test::<f::newton, l::millimeter, t::newton_millimeter>();
+            test::<f::newton, l::micrometer, t::newton_micrometer>();
+            test::<f::newton, l::nanometer, t::newton_nanometer>();
+            test::<f::newton, l::picometer, t::newton_picometer>();
+            test::<f::newton, l::femtometer, t::newton_femtometer>();
+            test::<f::newton, l::attometer, t::newton_attometer>();
+            test::<f::newton, l::zeptometer, t::newton_zeptometer>();
+            test::<f::newton, l::yoctometer, t::newton_yoctometer>();
+
+            test::<f::dyne, l::meter, t::dyne_meter>();
+            test::<f::dyne, l::centimeter, t::dyne_centimeter>();
+            test::<f::ounce_force, l::inch, t::ounce_force_inch>();
+            test::<f::pound_force, l::foot, t::pound_force_foot>();
+            test::<f::pound_force, l::inch, t::pound_force_inch>();
+
+            fn test<F: f::Conversion<V>, L: l::Conversion<V>, T: t::Conversion<V>>() {
+                Test::assert_approx_eq(&TorqueMagnitude::new::<T>(V::one()),
+                    &(Force::new::<F>(V::one()) * Length::new::<L>(V::one())));
+            }
+        }
+    }
+}


### PR DESCRIPTION
After a lot of experimentation I'm coming around to the idea that Moments are more trouble than they're worth.  So in that vein, I'm following your suggestion in #117 to not use a different `Kind` for torque, and to add it as a quantity.

To get that to work I had to refactor the quantity macro a bit to split the parts that must be repeated between aliases from the parts that cannot be.  I'm rather new to macros (I still find them very hard to read), so please bear with me if it takes some back and forth to clean these changes up.