### PR TITLE
Homogenize documentation

### DIFF
--- a/src/si/acceleration.rs
+++ b/src/si/acceleration.rs
@@ -1,9 +1,9 @@
-//! Acceleration (base unit meter per second<sup>2</sup>, m<sup>1</sup> · s<sup>-2</sup>).
+//! Acceleration (base unit meter per second squared, m · s⁻²).
 
 quantity! {
-    /// Acceleration (base unit meter per second<sup>2</sup>, m<sup>1</sup> · s<sup>-2</sup>).
+    /// Acceleration (base unit meter per second squared, m · s⁻²).
     quantity: Acceleration; "acceleration";
-    /// Acceleration dimension, m<sup>1</sup> · s<sup>-2</sup>.
+    /// Dimension of acceleration, LT⁻² (base unit meter per second squared, m · s⁻²).
     dimension: ISQ<
         P1,     // length
         Z0,     // mass

--- a/src/si/amount_of_substance.rs
+++ b/src/si/amount_of_substance.rs
@@ -1,9 +1,9 @@
-//! Amount of substance (base unit mole, mol<sup>1</sup>).
+//! Amount of substance (base unit mole, mol).
 
 quantity! {
-    /// Amount of substance (base unit mole, mol<sup>1</sup>).
+    /// Amount of substance (base unit mole, mol).
     quantity: AmountOfSubstance; "amount of substance";
-    /// Amount of substance dimension, mol<sup>1</sup>.
+    /// Dimension of amount of substance, N (base unit mole, mol).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/angle.rs
+++ b/src/si/angle.rs
@@ -1,13 +1,13 @@
-//! Angle (dimensionless).
+//! Angle (dimensionless quantity).
 
 /// AngleKind is a `Kind` for separating angular quantities from their indentically dimensioned
 /// non-angular quantity counterparts.
 pub trait AngleKind: ::Kind {}
 
 quantity! {
-    /// Angle (dimensionless).
+    /// Angle (dimensionless quantity).
     quantity: Angle; "angle";
-    /// Angle dimension (dimensionless).
+    /// Dimension of angle, 1 (dimensionless).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/area.rs
+++ b/src/si/area.rs
@@ -1,9 +1,9 @@
-//! Area (base unit square meter, m<sup>2</sup>).
+//! Area (base unit square meter, m²).
 
 quantity! {
-    /// Area (base unit square meter, m<sup>2</sup>).
+    /// Area (base unit square meter, m²).
     quantity: Area; "area";
-    /// Area dimension, m<sup>2</sup>.
+    /// Dimension of area, L² (base unit square meter, m²).
     dimension: ISQ<
         P2,     // length
         Z0,     // mass

--- a/src/si/available_energy.rs
+++ b/src/si/available_energy.rs
@@ -1,9 +1,9 @@
-//! Available energy (base unit joule per kilogram, m<sup>2</sup> · s<sup>-2</sup>).
+//! Available energy (base unit joule per kilogram, m² · s⁻²).
 
 quantity! {
-    /// Available energy (base unit joule per kilogram, m<sup>2</sup> · s<sup>-2</sup>).
+    /// Available energy (base unit joule per kilogram, m² · s⁻²).
     quantity: AvailableEnergy; "available energy";
-    /// Available energy dimension, m<sup>2</sup> · s<sup>-2</sup>.
+    /// Dimension of available energy, L²T⁻² (base unit joule per kilogram, m² · s⁻²).
     dimension: ISQ<
         P2,     // length
         Z0,     // mass

--- a/src/si/capacitance.rs
+++ b/src/si/capacitance.rs
@@ -1,10 +1,9 @@
-//! Capacitance (base unit farad, m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>4</sup> · A<sup>2</sup>).
+//! Capacitance (base unit farad, m⁻² · kg⁻¹ · s⁴ · A²).
 
 quantity! {
-    /// Capacitance (base unit farad, m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>4</sup> ·
-    /// A<sup>2</sup>).
+    /// Capacitance (base unit farad, m⁻² · kg⁻¹ · s⁴ · A²).
     quantity: Capacitance; "capacitance";
-    /// Capacitance dimension, m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>4</sup> · A<sup>2</sup>.
+    /// Dimension of capacitance, L⁻²M⁻¹T⁴I² (base unit farad, m⁻² · kg⁻¹ · s⁴ · A²).
     dimension: ISQ<
         N2,     // length
         N1,     // mass

--- a/src/si/density.rs
+++ b/src/si/density.rs
@@ -1,9 +1,9 @@
-//! Density (base unit kilogram per cubic meter, m<sup>-3</sup> · kg<sup>1</sup>).
+//! Density (base unit kilogram per cubic meter, kg · m⁻³).
 
 quantity! {
-    /// Density (base unit kilogram per cubic meter, m<sup>-3</sup> · kg<sup>1</sup>).
+    /// Density (base unit kilogram per cubic meter, kg · m⁻³).
     quantity: Density; "density";
-    /// Density dimension, m<sup>-3</sup> · kg<sup>1</sup>.
+    /// Dimension of density, L⁻³M (base unit kilogram per cubic meter, kg · m⁻³).
     dimension: ISQ<
         N3,     // length
         P1,     // mass

--- a/src/si/electric_charge.rs
+++ b/src/si/electric_charge.rs
@@ -3,7 +3,7 @@
 quantity! {
     /// Electric charge (base unit coulomb, A · s).
     quantity: ElectricCharge; "electric charge";
-    /// Electric charge dimension, A · s.
+    /// Dimension of electric charge, TI (base unit coulomb, A · s).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/electric_current.rs
+++ b/src/si/electric_current.rs
@@ -1,9 +1,9 @@
-//! Electric current (base unit ampere, A<sup>1</sup>).
+//! Electric current (base unit ampere, A).
 
 quantity! {
-    /// Electric current (base unit ampere, A<sup>1</sup>).
+    /// Electric current (base unit ampere, A).
     quantity: ElectricCurrent; "electric current";
-    /// Electric current dimension, A<sup>1</sup>.
+    /// Dimension of electric current, I (base unit ampere, A).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/electric_potential.rs
+++ b/src/si/electric_potential.rs
@@ -1,9 +1,9 @@
-//! Electric potential (base unit volt, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-1</sup>).
+//! Electric potential (base unit volt, m² · kg · s⁻³ · A⁻¹).
 
 quantity! {
-    /// Electric potential (base unit volt, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-1</sup>).
+    /// Electric potential (base unit volt, m² · kg · s⁻³ · A⁻¹).
     quantity: ElectricPotential; "electric potential";
-    /// Electric potential dimension, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-1</sup>.
+    /// Dimension of electric potential, L²MT⁻³I⁻¹ (base unit volt, m² · kg · s⁻³ · A⁻¹).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/electrical_conductance.rs
+++ b/src/si/electrical_conductance.rs
@@ -1,12 +1,9 @@
-//! Electrical conductance
-//! (base unit siemens, m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>3</sup> · A<sup>2</sup>).
+//! Electrical conductance (base unit siemens, m⁻² · kg⁻¹ · s³ · A²).
 
 quantity! {
-    /// Electrical conductance (base unit siemens,
-    /// m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>3</sup> · A<sup>2</sup>).
+    /// Electrical conductance (base unit siemens, m⁻² · kg⁻¹ · s³ · A²).
     quantity: ElectricalConductance; "electrical conductance";
-    /// Electrical conductance dimension,
-    /// m<sup>-2</sup> · kg<sup>-1</sup> · s<sup>3</sup> · A<sup>2</sup>.
+    /// Dimension of electrical conductance, L⁻²M⁻¹T³I² (base unit siemens, m⁻² · kg⁻¹ · s³ · A²).
     dimension: ISQ<
         N2,     // length
         N1,     // mass

--- a/src/si/electrical_resistance.rs
+++ b/src/si/electrical_resistance.rs
@@ -1,9 +1,9 @@
-//! Electrical resistance (base unit ohm, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-2</sup>).
+//! Electrical resistance (base unit ohm, m² · kg · s⁻³ · A⁻²).
 
 quantity! {
-    /// Electrical resistance (base unit ohm, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-2</sup>).
+    /// Electrical resistance (base unit ohm, m² · kg · s⁻³ · A⁻²).
     quantity: ElectricalResistance; "electrical resistance";
-    /// Electrical resistance dimension, m<sup>2</sup> · kg · s<sup>-3</sup> · A<sup>-2</sup>.
+    /// Dimension of electrical resistance, L²MT⁻³I⁻² (base unit ohm, m² · kg · s⁻³ · A⁻²).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/energy.rs
+++ b/src/si/energy.rs
@@ -1,9 +1,9 @@
-//! Energy (base unit joule, m<sup>2</sup> · kg · s<sup>-2</sup>).
+//! Energy (base unit joule, kg · m² · s⁻²).
 
 quantity! {
-    /// Energy (base unit joule, m<sup>2</sup> · kg · s<sup>-2</sup>).
+    /// Energy (base unit joule, kg · m² · s⁻²).
     quantity: Energy; "energy";
-    /// Energy dimension, m<sup>2</sup> · kg · s<sup>-2</sup>.
+    /// Dimension of energy, L²MT⁻² (base unit joule, kg · m² · s⁻²).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/force.rs
+++ b/src/si/force.rs
@@ -1,9 +1,9 @@
-//! Force (base unit newton, kg<sup>1</sup> · m<sup>1</sup> · s<sup>-2</sup>).
+//! Force (base unit newton, kg · m · s⁻²).
 
 quantity! {
-    /// Force (base unit newton, kg<sup>1</sup> · m<sup>1</sup> · s<sup>-2</sup>).
+    /// Force (base unit newton, kg · m · s⁻²).
     quantity: Force; "force";
-    /// Force dimension, kg<sup>1</sup> · m<sup>1</sup> · s<sup>-2</sup>.
+    /// Dimension of force, LMT⁻² (base unit newton, kg · m · s⁻²).
     dimension: ISQ<
         P1,     // length
         P1,     // mass

--- a/src/si/frequency.rs
+++ b/src/si/frequency.rs
@@ -1,9 +1,9 @@
-//! Frequency (base unit hertz, s<sup>-1</sup>).
+//! Frequency (base unit hertz, s⁻¹).
 
 quantity! {
-    /// Frequency (base unit hertz, s<sup>-1</sup>).
+    /// Frequency (base unit hertz, s⁻¹).
     quantity: Frequency; "frequency";
-    /// Frequency dimension, s<sup>-1</sup>.
+    /// Dimension of frequency, T⁻¹ (base unit hertz, s⁻¹).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/inductance.rs
+++ b/src/si/inductance.rs
@@ -1,10 +1,9 @@
-//! Inductance (base unit henry, m<sup>2</sup> · kg<sup>1</sup> · s<sup>-2</sup> · A<sup>-2</sup>).
+//! Inductance (base unit henry, m² · kg · s⁻² · A⁻²).
 
 quantity! {
-    /// Inductance (base unit henry, m<sup>2</sup> · kg<sup>1</sup> · s<sup>-2</sup> ·
-    /// A<sup>-2</sup>).
+    /// Inductance (base unit henry, m² · kg · s⁻² · A⁻²).
     quantity: Inductance; "inductance";
-    /// Inductance dimension, m<sup>2</sup> · kg<sup>1</sup> · s<sup>-2</sup> · A<sup>-2</sup>.
+    /// Dimension of inductance, L²MT⁻²I⁻² (base unit henry, m² · kg · s⁻² · A⁻²).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/jerk.rs
+++ b/src/si/jerk.rs
@@ -1,9 +1,9 @@
-//! Jerk (base unit meter per second<sup>3</sup>, m<sup>1</sup> · s<sup>-3</sup>).
+//! Jerk (base unit meter per second cubed, m · s⁻³).
 
 quantity! {
-    /// Jerk (base unit meter per second<sup>3</sup>, m<sup>1</sup> · s<sup>-3</sup>).
+    /// Jerk (base unit meter per second cubed, m · s⁻³).
     quantity: Jerk; "jerk";
-    /// Jerk dimension, m<sup>1</sup> · s<sup>-3</sup>.
+    /// Dimension of jerk, LT⁻³ (base unit meter per second cubed, m · s⁻³).
     dimension: ISQ<
         P1,     // length
         Z0,     // mass

--- a/src/si/length.rs
+++ b/src/si/length.rs
@@ -1,9 +1,9 @@
-//! Length (base unit meter, m<sup>1</sup>).
+//! Length (base unit meter, m).
 
 quantity! {
-    /// Length (base unit meter, m<sup>1</sup>).
+    /// Length (base unit meter, m).
     quantity: Length; "length";
-    /// Length dimension, m<sup>1</sup>.
+    /// Dimension of length, L (base unit meter, m).
     dimension: ISQ<
         P1,     // length
         Z0,     // mass

--- a/src/si/luminance.rs
+++ b/src/si/luminance.rs
@@ -1,9 +1,9 @@
-//! Luminance (base unit candela per square meter, cd<sup>1</sup> · m<sup>-2</sup>).
+//! Luminance (base unit candela per square meter, cd · m⁻²).
 
 quantity! {
-    /// Luminance (base unit candela per square meter, cd<sup>1</sup> · m<sup>-2</sup>).
+    /// Luminance (base unit candela per square meter, cd · m⁻²).
     quantity: Luminance; "luminance";
-    /// Luminance dimension, cd<sup>1</sup> · m<sup>-2</sup>.
+    /// Dimension of luminance, L⁻²J (base unit candela per square meter, cd · m⁻²).
     dimension: ISQ<
         N2,     // length
         Z0,     // mass

--- a/src/si/luminous_intensity.rs
+++ b/src/si/luminous_intensity.rs
@@ -1,9 +1,9 @@
-//! Luminous intensity (base unit candela, cd<sup>1</sup>).
+//! Luminous intensity (base unit candela, cd).
 
 quantity! {
-    /// Luminous intensity (base unit candela, cd<sup>1</sup>).
+    /// Luminous intensity (base unit candela, cd).
     quantity: LuminousIntensity; "luminous intensity";
-    /// Luminous intensity dimension, cd<sup>1</sup>.
+    /// Dimension of luminous intensity, J (base unit candela, cd).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/magnetic_flux.rs
+++ b/src/si/magnetic_flux.rs
@@ -1,9 +1,9 @@
-//! Magnetic flux (base unit weber, m<sup>2</sup> · kg · s<sup>-2</sup> · A<sup>-1</sup>).
+//! Magnetic flux (base unit weber, m² · kg · s⁻² · A⁻¹).
 
 quantity! {
-    /// Magnetic flux (base unit weber, m<sup>2</sup> · kg · s<sup>-2</sup> · A<sup>-1</sup>).
+    /// Magnetic flux (base unit weber, m² · kg · s⁻² · A⁻¹).
     quantity: MagneticFlux; "magnetic flux";
-    /// Magnetic flux dimension, m<sup>2</sup> · kg · s<sup>-2</sup> · A<sup>-1</sup>.
+    /// Dimension of magnetic flux, L²MT⁻²I⁻¹ (base unit weber, m² · kg · s⁻² · A⁻¹).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/magnetic_flux_density.rs
+++ b/src/si/magnetic_flux_density.rs
@@ -1,9 +1,9 @@
-//! Magnetic flux density (base unit tesla, kg · s<sup>-2</sup> · A<sup>-1</sup>).
+//! Magnetic flux density (base unit tesla, kg · s⁻² · A⁻¹).
 
 quantity! {
-    /// Magnetic flux density (base unit tesla, kg · s<sup>-2</sup> · A<sup>-1</sup>).
+    /// Magnetic flux density (base unit tesla, kg · s⁻² · A⁻¹).
     quantity: MagneticFluxDensity; "magnetic flux density";
-    /// Magnetic flux density dimension, kg · s<sup>-2</sup> · A<sup>-1</sup>.
+    /// Dimension of magnetic flux density, MT⁻²I⁻¹ (base unit tesla, kg · s⁻² · A⁻¹).
     dimension: ISQ<
         Z0,     // length
         P1,     // mass

--- a/src/si/mass.rs
+++ b/src/si/mass.rs
@@ -1,9 +1,9 @@
-//! Mass (base unit kilogram, kg<sup>1</sup>).
+//! Mass (base unit kilogram, kg).
 
 quantity! {
-    /// Mass (base unit kilogram, kg<sup>1</sup>).
+    /// Mass (base unit kilogram, kg).
     quantity: Mass; "mass";
-    /// Mass dimension, kg<sup>1</sup>.
+    /// Mass dimension, M (base unit kilogram, kg).
     dimension: ISQ<
         Z0,     // length
         P1,     // mass

--- a/src/si/mass_rate.rs
+++ b/src/si/mass_rate.rs
@@ -1,9 +1,9 @@
-//! Mass rate (base unit kilogram per second, kg<sup>1</sup> · s<sup>-1</sup>).
+//! Mass rate (base unit kilogram per second, kg · s⁻¹).
 
 quantity! {
-    /// Mass rate (base unit kilogram per second, kg<sup>1</sup> · s<sup>-1</sup>).
+    /// Mass rate (base unit kilogram per second, kg · s⁻¹).
     quantity: MassRate; "mass rate";
-    /// Mass rate dimension, kg<sup>1</sup> · s<sup>-1</sup>.
+    /// Dimension of mass rate, MT⁻¹ (base unit kilogram per second, kg · s⁻¹).
     dimension: ISQ<
         Z0,     // length
         P1,     // mass

--- a/src/si/momentum.rs
+++ b/src/si/momentum.rs
@@ -1,10 +1,9 @@
-//! Momentum (base unit kilogram meter per second, kg<sup>1</sup> · m<sup>1</sup> · s<sup>-1</sup>).
+//! Momentum (base unit kilogram meter per second, kg · m · s⁻¹).
 
 quantity! {
-    /// Momentum (base unit kilogram meter per second, kg<sup>1</sup> · m<sup>1</sup> ·
-    /// s<sup>-1</sup>).
+    /// Momentum (base unit kilogram meter per second, kg · m · s⁻¹).
     quantity: Momentum; "momentum";
-    /// Momentum dimension, kg<sup>1</sup> · m<sup>1</sup> · s<sup>-1</sup>.
+    /// Dimension of momentum, LMT⁻¹ (base unit kilogram meter per second, kg · m · s⁻¹).
     dimension: ISQ<
         P1,     // length
         P1,     // mass

--- a/src/si/power.rs
+++ b/src/si/power.rs
@@ -1,9 +1,9 @@
-//! Power (base unit watt, m<sup>2</sup> · kg · s<sup>-3</sup>).
+//! Power (base unit watt, m² · kg · s⁻³).
 
 quantity! {
-    /// Available energy (base unit watt, m<sup>2</sup> · kg · s<sup>-3</sup>).
+    /// Power (base unit watt, m² · kg · s⁻³).
     quantity: Power; "power";
-    /// Power dimension, m<sup>2</sup> · kg · s<sup>-3</sup>.
+    /// Dimension of power, L²MT⁻³ (base unit watt, m² · kg · s⁻³).
     dimension: ISQ<
         P2,     // length
         P1,     // mass

--- a/src/si/pressure.rs
+++ b/src/si/pressure.rs
@@ -1,9 +1,9 @@
-//! Pressure (base unit pascal, kg<sup>1</sup> · m<sup>-1</sup> · s<sup>-2</sup>).
+//! Pressure (base unit pascal, kg · m⁻¹ · s⁻²).
 
 quantity! {
-    /// Pressure (base unit pascal, kg<sup>1</sup> · m<sup>-1</sup> · s<sup>-2</sup>).
+    /// Pressure (base unit pascal, kg · m⁻¹ · s⁻²).
     quantity: Pressure; "pressure";
-    /// Pressure dimension, kg<sup>1</sup> · m<sup>-1</sup> · s<sup>-2</sup>.
+    /// Dimension of pressure, L⁻¹MT⁻² (base unit pascal, kg · m⁻¹ · s⁻²).
     dimension: ISQ<
         N1,     // length
         P1,     // mass

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -1,9 +1,9 @@
-//! Ratio (dimensionless).
+//! Ratio (dimensionless quantity).
 
 quantity! {
-    /// Ratio (dimensionless).
+    /// Ratio (dimensionless quantity).
     quantity: Ratio; "ratio";
-    /// Ratio dimension (dimensionless).
+    /// Dimension of ratio, 1 (dimensionless).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/temperature_interval.rs
+++ b/src/si/temperature_interval.rs
@@ -1,4 +1,4 @@
-//! Temperature interval (base unit kelvin, K<sup>1</sup>).
+//! Temperature interval (base unit kelvin, K).
 //!
 //! Temperature interval has the same dimensions as [thermodynamic temperature][tt] but is not
 //! directly comparable. See [thermodynamic temperature][tt] for a full explanation.
@@ -8,9 +8,9 @@
 use si::thermodynamic_temperature::ThermodynamicTemperature;
 
 quantity! {
-    /// Temperature interval (base unit kelvin, K<sup>1</sup>).
+    /// Temperature interval (base unit kelvin, K).
     quantity: TemperatureInterval; "temperature interval";
-    /// Temperature interval dimension, K<sup>1</sup>.
+    /// Dimension of temperature interval, Th (base unit kelvin, K).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/thermodynamic_temperature.rs
+++ b/src/si/thermodynamic_temperature.rs
@@ -1,4 +1,4 @@
-//! Thermodynamic temperature (base unit kelvin, K<sup>1</sup>).
+//! Thermodynamic temperature (base unit kelvin, K).
 //!
 //! Thermodynamic temperature has the same dimensions as [temperature
 //! interval](../temperature_interval/index.html) but is not directly comparable. Thermodynamic
@@ -56,9 +56,9 @@ pub trait Temperature
 }
 
 quantity! {
-    /// Thermodynamic temperature (base unit kelvin, K<sup>1</sup>).
+    /// Thermodynamic temperature (base unit kelvin, K).
     quantity: ThermodynamicTemperature; "thermodynamic temperature";
-    /// Thermodynamic temperature dimension, K<sup>1</sup>.
+    /// Dimension of thermodynamic temperature, Th (base unit kelvin, K).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -1,9 +1,9 @@
-//! Time (base unit second, s<sup>1</sup>).
+//! Time (base unit second, s).
 
 quantity! {
-    /// Time (base unit second, s<sup>1</sup>).
+    /// Time (base unit second, s).
     quantity: Time; "time";
-    /// Time dimension, s<sup>1</sup>.
+    /// Dimension of time, T (base unit second, s).
     dimension: ISQ<
         Z0,     // length
         Z0,     // mass

--- a/src/si/velocity.rs
+++ b/src/si/velocity.rs
@@ -1,9 +1,9 @@
-//! Velocity (base unit meter per second, m<sup>1</sup> · s<sup>-1</sup>).
+//! Velocity (base unit meter per second, m · s⁻¹).
 
 quantity! {
-    /// Velocity (base unit meter per second, m<sup>1</sup> · s<sup>-1</sup>).
+    /// Velocity (base unit meter per second, m · s⁻¹).
     quantity: Velocity; "velocity";
-    /// Velocity dimension, m<sup>1</sup> · s<sup>-1</sup>.
+    /// Dimension of velocity, LT⁻¹ (base unit meter per second, m · s⁻¹).
     dimension: ISQ<
         P1,     // length
         Z0,     // mass

--- a/src/si/volume.rs
+++ b/src/si/volume.rs
@@ -1,9 +1,9 @@
-//! Volume (base unit cubic meter, m<sup>3</sup>).
+//! Volume (base unit cubic meter, m³).
 
 quantity! {
-    /// Volume (base unit cubic meter, m<sup>3</sup>).
+    /// Volume (base unit cubic meter, m³).
     quantity: Volume; "volume";
-    /// Volume dimension, m<sup>3</sup>.
+    /// Dimension of volume, L³ (base unit cubic meter, m³).
     dimension: ISQ<
         P3,     // length
         Z0,     // mass

--- a/src/si/volume_rate.rs
+++ b/src/si/volume_rate.rs
@@ -1,9 +1,9 @@
-//! Volume (base unit cubic meter per second, m<sup>3</sup> · s<sup>-1</sup>).
+//! Volume rate (base unit cubic meter per second, m³ · s⁻¹).
 
 quantity! {
-    /// Volume rate (base unit cubic meter per second, m<sup>3</sup> · s<sup>-1</sup>).
+    /// Volume rate (base unit cubic meter per second, m³ · s⁻¹).
     quantity: VolumeRate; "volume rate";
-    /// Volume dimension, m<sup>3</sup> · s<sup>-1</sup>.
+    /// Dimension of volume rate, L³T⁻¹ (base unit cubic meter per second, m³ · s⁻¹).
     dimension: ISQ<
         P3,     // length
         Z0,     // mass


### PR DESCRIPTION
As discussed in #127. I also went ahead and renamed density to "mass density," as this is more appropriate. If desired, I can separate that change into another PR and maybe set up an alias or something.

There are a couple of places where "dimension of `X`" is weird (especially `Ratio` and `Angle`); do we want to special-case these or just let them sound weird?