### PR TITLE
Maintain kind when multplying a number by a quantity.

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -510,7 +510,8 @@ macro_rules! system {
                                 $quantities<
                                     $($crate::typenum::$AddSubAlias<
                                       $crate::typenum::Z0,
-                                      D::$symbol>,)+>,
+                                      D::$symbol>,)+
+                                      D::Kind>,
                                 U, V>;
 
                             #[inline(always)]


### PR DESCRIPTION
`1.0 * Q` and `1.0 / Q` now both maintain Q's kind in the result. `Q *
1.0` and `Q / 1.0` already maintain the kind. Resolves #138.