### PR TITLE
Correct `Quantity::new` to be zero-cost for float storage types.

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -176,8 +176,9 @@ macro_rules! quantity {
                 }
 
                 #[inline(always)]
-                fn constant() -> Self::T {
-                    quantity!(@constant $($conversion),+)
+                #[allow(unused_variables)]
+                fn constant(op: $crate::ConstantOp) -> Self::T {
+                    quantity!(@constant op $($conversion),+)
                 }
             }
 
@@ -202,8 +203,9 @@ macro_rules! quantity {
                 }
 
                 #[inline(always)]
-                fn constant() -> Self::T {
-                    from_f64(quantity!(@constant $($conversion),+))
+                #[allow(unused_variables)]
+                fn constant(op: $crate::ConstantOp) -> Self::T {
+                    from_f64(quantity!(@constant op $($conversion),+))
                 }
             }
 
@@ -233,8 +235,9 @@ macro_rules! quantity {
                 }
 
                 #[inline(always)]
-                fn constant() -> Self::T {
-                    from_f64(quantity!(@constant $($conversion),+))
+                #[allow(unused_variables)]
+                fn constant(op: $crate::ConstantOp) -> Self::T {
+                    from_f64(quantity!(@constant op $($conversion),+))
                 }
             }
 
@@ -258,8 +261,9 @@ macro_rules! quantity {
                 }
 
                 #[inline(always)]
-                fn constant() -> Self::T {
-                    from_f64(quantity!(@constant $($conversion),+))
+                #[allow(unused_variables)]
+                fn constant(op: $crate::ConstantOp) -> Self::T {
+                    from_f64(quantity!(@constant op $($conversion),+))
                 }
             }
 
@@ -492,6 +496,11 @@ macro_rules! quantity {
     };
     (@coefficient $factor:expr, $const:expr) => { $factor };
     (@coefficient $factor:expr) => { $factor };
-    (@constant $factor:expr, $const:expr) => { $const };
-    (@constant $factor:expr) => { 0.0 };
+    (@constant $op:ident $factor:expr, $const:expr) => { $const };
+    (@constant $op:ident $factor:expr) => {
+        match $op {
+            $crate::ConstantOp::Add => -0.0,
+            $crate::ConstantOp::Sub => 0.0,
+        }
+    };
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -282,7 +282,7 @@ macro_rules! system {
             use $crate::ConversionFactor;
 
             (v.into_conversion() $(* U::$name::coefficient().powi(D::$symbol::to_i32()))+
-                    / N::coefficient() - N::constant())
+                    / N::coefficient() - N::constant($crate::ConstantOp::Sub))
                 .value()
         }
 
@@ -299,7 +299,7 @@ macro_rules! system {
             use $crate::Conversion;
             use $crate::ConversionFactor;
 
-            ((v.into_conversion() + N::constant()) * N::coefficient()
+            ((v.into_conversion() + N::constant($crate::ConstantOp::Add)) * N::coefficient()
                     / (V::coefficient() $(* U::$name::coefficient().powi(D::$symbol::to_i32()))+))
                 .value()
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,7 +16,7 @@ use str::ParseQuantityError;
 #[allow(unused_imports)]
 use typenum::{N1, P1, P2, P3, Z0};
 #[allow(unused_imports)]
-use {Conversion, ConversionFactor};
+use {ConstantOp, Conversion, ConversionFactor};
 
 #[macro_use]
 mod length {

--- a/src/tests/quantities.rs
+++ b/src/tests/quantities.rs
@@ -86,9 +86,10 @@ storage_types! {
 
     #[test]
     fn constant() {
-        Test::assert_eq(&V::zero(), &<kilogram as Conversion<V>>::constant().value());
+        Test::assert_eq(&V::zero(),
+            &<kilogram as Conversion<V>>::constant(ConstantOp::Add).value());
         Test::assert_eq(&V::from_f64(459.67).unwrap(),
-            &<degree_fahrenheit as Conversion<V>>::constant().value());
+            &<degree_fahrenheit as Conversion<V>>::constant(ConstantOp::Add).value());
     }
 
     #[cfg(feature = "std")]

--- a/src/tests/system.rs
+++ b/src/tests/system.rs
@@ -24,7 +24,8 @@ storage_types! {
         {
             let km: V = <kilometer as ::Conversion<V>>::coefficient().value();
             let f_coefficient: V = <degree_fahrenheit as ::Conversion<V>>::coefficient().value();
-            let f_constant: V = <degree_fahrenheit as ::Conversion<V>>::constant().value();
+            let f_constant: V =
+                <degree_fahrenheit as ::Conversion<V>>::constant(ConstantOp::Add).value();
 
             // meter -> meter.
             Test::approx_eq(&*v,
@@ -63,7 +64,8 @@ storage_types! {
         {
             let km: V = <kilometer as ::Conversion<V>>::coefficient().value();
             let f_coefficient: V = <degree_fahrenheit as ::Conversion<V>>::coefficient().value();
-            let f_constant: V = <degree_fahrenheit as ::Conversion<V>>::constant().value();
+            let f_constant: V =
+                <degree_fahrenheit as ::Conversion<V>>::constant(ConstantOp::Add).value();
 
             // meter -> meter.
             Test::approx_eq(&*v,


### PR DESCRIPTION
Use a default constant of `-0.0` to allow for floating point
optimizations. For a value, `v: Float`, adding `-0.0` is a no-op while
adding `0.0` will change the sign if `v` is `-0.0`. Resolves #143.

```
   v
 0.0 + -0.0 =  0.0
-0.0 +  0.0 =  0.0 # v + 0.0 != v
-0.0 + -0.0 = -0.0
```

@raimundomartins with the changes in this PR your example program generates the expected zero-cost LLVM-IR! If you could review / test with your full code that would be greatly appreciated.

```llvm
; call uom_opt_test::value
%0 = tail call fastcc double @_ZN12uom_opt_test5value17h5bf2d6ab643b092cE(double 1.111100e+04)
; call uom_opt_test::value
%1 = tail call fastcc double @_ZN12uom_opt_test5value17h5bf2d6ab643b092cE(double 2.222200e+04)
; call uom_opt_test::half_way
%2 = tail call fastcc double @_ZN12uom_opt_test8half_way17h905d0903778e0b79E(double %0)
; call uom_opt_test::half_way
%3 = tail call fastcc double @_ZN12uom_opt_test8half_way17h905d0903778e0b79E(double %1)
```