### PR TITLE
Increase minimum supported `rustc` version to 1.28.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 sudo: false
 
 rust:
-- 1.24.1    # Oldest supported
+- 1.28.0    # Oldest supported
 - stable
 - beta
 - nightly
@@ -18,15 +18,12 @@ matrix:
   allow_failures:
   - rust: nightly
   include:
-  - name: "Rust: 1.22.0"   # Oldest compiled
-    rust: 1.22.0
-    script: |
-      cargo build --verbose --features "use_serde"
   - name: "Rust: stable + tests"
     rust: stable
     script: |
       set -e
       cargo test --all --verbose --features "use_serde"
+      cargo test --manifest-path tests/edition_check/Cargo.toml --verbose --features "use_serde"
       cargo test --verbose --no-default-features --features "f32 si"
       cargo test --verbose --no-default-features --features "autoconvert f32 si use_serde"
       cargo test --verbose --no-run --no-default-features --features "autoconvert usize isize bigint bigrational si std use_serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,12 @@ maintenance = { status = "actively-developed" }
 
 [workspace]
 members = [
+    "tests/feature_check",
+]
+# Temporary exclusion. edition is unstable and not ignored in 1.28.0
+exclude = [
     "uom-macros",
     "tests/edition_check",
-    "tests/feature_check",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ uom
 ===
 [![Travis](https://travis-ci.org/iliekturtles/uom.svg?branch=master)](https://travis-ci.org/iliekturtles/uom)
 [![Coveralls](https://coveralls.io/repos/github/iliekturtles/uom/badge.svg?branch=master)](https://coveralls.io/github/iliekturtles/uom?branch=master)
-[![Rustup.rs](https://img.shields.io/badge/rustc-1.24.1%2B-orange.svg)](https://rustup.rs/)
+[![Rustup.rs](https://img.shields.io/badge/rustc-1.28.0%2B-orange.svg)](https://rustup.rs/)
 [![Crates.io](https://img.shields.io/crates/v/uom.svg)](https://crates.io/crates/uom)
 [![Crates.io](https://img.shields.io/crates/l/uom.svg)](https://crates.io/crates/uom)
 [![Documentation](https://img.shields.io/badge/documentation-docs.rs-blue.svg)](https://docs.rs/uom)
@@ -23,7 +23,7 @@ Units of measurement is a crate that does automatic type-safe zero-cost
 [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 
 ## Usage
-`uom` requires `rustc` 1.24.1 or later. Add this to your `Cargo.toml`:
+`uom` requires `rustc` 1.28.0 or later. Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -116,8 +116,8 @@ Rather than working with [measurement units](http://jcgm.bipm.org/vim/en/1.9.htm
 kilometer, foot, mile, ...) `uom` works with [quantities](http://jcgm.bipm.org/vim/en/1.1.html)
 (length, mass, time, ...). This simplifies usage because units are only involved at interface
 boundaries: the rest of your code only needs to be concerned about the quantities involved. This
-also makes operations on quantities (+, -, \*, /, ...) have zero runtime cost<sup>1</sup> over
-using the raw storage type (e.g. `f32`).
+also makes operations on quantities (+, -, \*, /, ...) have zero runtime cost over using the raw
+storage type (e.g. `f32`).
 
 `uom` normalizes values to the [base unit](http://jcgm.bipm.org/vim/en/1.10.html) for the quantity.
 Alternative base units can be used by executing the macro defined for the system of quantities
@@ -132,9 +132,6 @@ then values like `1 centimeter` or `1.1 meter` cannot be represented. `1 centime
 to `0.01 meter` which can't be stored in an `i32`. `uom` only allows units to be used safely. Users
 of this library will still need to be aware of implementation details of the underlying storage type
 including limits and precision.
-
- 1. As of `rustc` 1.25.0 where codegen bug [#38269](https://github.com/rust-lang/rust/issues/38269)
-    is resolved.
 
 ## Contributing
 Contributions are welcome from everyone. Submit a pull request, an issue, or just add comments to an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 //!
 //! ## Usage
-//! `uom` requires `rustc` 1.24.1 or later. Add this to your `Cargo.toml`:
+//! `uom` requires `rustc` 1.28.0 or later. Add this to your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
@@ -104,9 +104,9 @@
 //! Rather than working with [measurement units](http://jcgm.bipm.org/vim/en/1.9.html) (meter,
 //! kilometer, foot, mile, ...) `uom` works with [quantities](http://jcgm.bipm.org/vim/en/1.1.html)
 //! (length, mass, time, ...). This simplifies usage because units are only involved at interface
-//! boundaries: the rest of your code only needs to be concerned about the quantities involved. This
-//! also makes operations on quantities (+, -, \*, /, ...) have zero runtime cost<sup>1</sup> over
-//! using the raw storage type (e.g. `f32`).
+//! boundaries: the rest of your code only needs to be concerned about the quantities involved.
+//! This also makes operations on quantities (+, -, \*, /, ...) have zero runtime cost over using
+//! the raw storage type (e.g. `f32`).
 //!
 //! `uom` normalizes values to the [base unit](http://jcgm.bipm.org/vim/en/1.10.html) for the
 //! quantity. Alternative base units can be used by executing the macro defined for the system of
@@ -121,9 +121,6 @@
 //! centimeter` is normalized to `0.01 meter` which can't be stored in an `i32`. `uom` only allows
 //! units to be used safely. Users of this library will still need to be aware of implementation
 //! details of the underlying storage type including limits and precision.
-//!
-//!  1. As of `rustc` 1.25.0 where codegen bug
-//!    [#38269](https://github.com/rust-lang/rust/issues/38269) is resolved.
 //!
 //! ## Contributing
 //! Contributions are welcome from everyone. Submit a pull request, an issue, or just add comments


### PR DESCRIPTION
Changed in anticipation of adding `#[repr(transparent)]` in #145.
Zero-cost codegen note regarding `rustc` 1.25.0 is now no longer
relevant.