### PR TITLE
Implement TryFrom<Time> for Duration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       cargo test --verbose --no-default-features --features "f32 si"
       cargo test --verbose --no-default-features --features "autoconvert f32 si use_serde"
       cargo test --verbose --no-run --no-default-features --features "autoconvert usize isize bigint bigrational si std use_serde"
-      cargo test --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 isize i8 i16 i32 i64 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde"
+      cargo test --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 isize i8 i16 i32 i64 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde try-from"
   - name: Rustfmt
     rust: 1.35.0
     install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ use_serde = ["serde"]
 # Internal features to include appropriate num-* crates.
 rational-support = ["num-rational"]
 bigint-support = ["num-bigint", "num-rational/bigint"]
+# The `try-from` feature currently provides `impl TryFrom<Time> for Duration` and 
+# `impl TryFrom<Duration> for Time`. These traits were stabilized in Rust 1.34.0, so this feature
+# will not work on earlier Rust versions.
+try-from = []
 
 [[example]]
 name = "base"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ pub mod num {
     #[cfg(not(feature = "std"))]
     pub use num_traits::float::FloatCore as Float;
 
-    pub use num_traits::{pow, FromPrimitive, Num, One, Saturating, Signed, Zero};
+    pub use num_traits::{pow, AsPrimitive, FromPrimitive, Num, One, Saturating, Signed, Zero};
 
     #[cfg(feature = "bigint-support")]
     pub use num_bigint::{BigInt, BigUint};

--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -44,3 +44,150 @@ quantity! {
         @year: 3.1536_E7; "a", "year", "years";
     }
 }
+
+
+/// `Time` ⇌ `Duration` conversions.
+#[cfg(feature = "try-from")]
+pub mod convert {
+    use lib::time::Duration;
+    use num::{AsPrimitive, FromPrimitive, Zero};
+    use super::{nanosecond, second, Time};
+    
+    /// An error encountered in converting a `Time` to a `Duration`.
+    #[derive(Debug, Clone, Copy)]
+    pub enum TryFromError {
+        /// The given time interval was negative, making conversion to a duration nonsensical.
+        ///
+        /// To convert a negative time interval to a duration, first use `abs` to make it positive.
+        NegativeDuration,
+        /// The given time interval exceeded the maximum size of a `Duration`.
+        Overflow,
+    }
+
+    /// Attempts to convert the given `Time` to a `Duration`.
+    ///
+    /// For possible failure modes, see [`TryFromError`][TryFromError].
+    ///
+    /// ## Notes
+    ///
+    /// The `Duration` to `Time` conversion is tested to be accurate to within 1 nanosecond
+    /// (to allow for floating point rounding error). If greater precision is needed, consider
+    /// using a different backing storage type or avoiding the conversion altogether.
+    ///
+    /// [TryFromError]: enum.TryFromError.html
+    impl<U, V> ::lib::convert::TryFrom<Time<U, V>> for Duration
+    where
+        U: ::si::Units<V> + ?Sized,
+        V: ::num::Num + ::Conversion<V> + ::lib::cmp::PartialOrd + AsPrimitive<u64> + AsPrimitive<u32>,
+        second: ::Conversion<V, T = V::T>,
+        nanosecond: ::Conversion<V, T = V::T>,
+    {
+        type Error = TryFromError;
+    
+        fn try_from(time: Time<U, V>) -> Result<Self, Self::Error> {
+            if time < Time::<U, V>::zero() {
+                return Err(TryFromError::NegativeDuration);
+            }
+    
+            let secs = time.get::<second>().as_();
+            let nanos = (time % Time::<U, V>::new::<second>(V::one())).get::<nanosecond>().as_();
+    
+            Ok(Duration::new(secs, nanos))
+        }
+    }
+    
+    impl<U, V> ::lib::convert::TryFrom<Duration> for Time<U, V>
+    where
+        U: ::si::Units<V> + ?Sized,
+        V: ::num::Num + ::Conversion<V> + FromPrimitive,
+        second: ::Conversion<V, T = V::T>,
+        nanosecond: ::Conversion<V, T = V::T>,
+    {
+        type Error = TryFromError;
+        /// Attempts to convert the given `Duration` to a `Time`.
+        ///
+        /// For possible failure modes, see [`TryFromError`][TryFromError].
+        ///
+        /// ## Notes
+        ///
+        /// The `Duration` to `Time` conversion is tested to be accurate to within 100 nanoseconds
+        /// (to allow for floating point rounding error). If greater precision is needed, consider
+        /// using a different backing storage type or avoiding the conversion altogether.
+        ///
+        /// [TryFromError]: enum.TryFromError.html
+        fn try_from(duration: Duration) -> Result<Self, Self::Error> {
+            let secs = V::from_u64(duration.as_secs());
+            let nanos = V::from_u32(duration.subsec_micros());
+    
+            match (secs, nanos) {
+                (Some(secs), Some(nanos)) => {
+                    Ok(Time::<U, V>::new::<second>(secs) + Time::<U, V>::new::<nanosecond>(nanos))
+                },
+                _ => Err(TryFromError::Overflow),
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "try-from"))]
+mod tests {
+    storage_types! {
+        use lib::convert::{TryFrom, TryInto};
+        use lib::time::Duration;
+        use num::{AsPrimitive, FromPrimitive, Zero};
+        use tests::*;
+        use si::quantities::*;
+        use si::time::nanosecond;
+        use si::time::convert::TryFromError;
+        use quickcheck::TestResult;
+
+        quickcheck! {
+            fn duration_try_from(v: A<V>) -> TestResult {
+               test_try_from(Duration::try_from(Time::new::<nanosecond>(*v)), v)
+            }
+
+            fn time_try_into(v: A<V>) -> TestResult {
+                test_try_from(Time::new::<nanosecond>(*v).try_into(), v)
+            }
+
+            fn time_try_from(v: A<V>) -> TestResult {
+                if *v < V::zero() {
+                    return TestResult::discard();
+                }
+                test_try_into(Time::try_from(Duration::from_nanos(v.as_())), v)
+            }
+
+            fn duration_try_into(v: A<V>) -> TestResult {
+                if *v < V::zero() {
+                    return TestResult::discard();
+                }
+
+                test_try_into(Duration::from_nanos(v.as_()).try_into(), v)
+            }
+        }
+
+        fn test_try_from(t: Result<Duration, TryFromError>, v: A<V>) -> TestResult {
+            let ok = match (t, *v >= V::zero()) {
+                (Ok(t), true) => {
+                    let d = Duration::from_nanos(v.as_());
+                    let r = if d > t { d - t } else { t - d };
+                    Duration::from_nanos(1) >= r
+                },
+                (Err(_), false) => true,
+                _ => false,
+            };
+            TestResult::from_bool(ok)
+        }
+        
+        fn test_try_into(t: Result<Time<V>, TryFromError>, v: A<V>) -> TestResult {
+            let ok = if let Ok(t) = t {
+                let b = Time::new::<nanosecond>(v.as_());
+                let d = if t > b { t - b } else { b - t };
+                d <= Time::new::<nanosecond>(V::from_u8(100).unwrap())
+            } else {
+                false
+            };
+            TestResult::from_bool(ok)
+        }
+    }
+}


### PR DESCRIPTION
This PR changes @dunmatt's work from `From<Time>` to `TryFrom<Time>`. I don't see any other bad inputs that `uom` has to handle explicitly itself except for a negative value; let me know if there's some other error case to consider.

The glaringly obvious omission here is a version check: `TryFrom`/`TryInto` only exists on stable in Rust 1.35 and later, but the minimum version is 1.28. I don't see anywhere else in the crate that deals with this (though I could've sworn there was something), but I wanted to see how you'd like to handle that. It could easily be an opt-in feature, with the burden of version correctness falling on the user, but maybe we want to use something else? I'm not sure a `build.rs` would be great to introduce for just this, but I'm not really sure what else exists, so here's me soliciting ideas. 