### PR TITLE
Use `f{32|64}::powi` instead of `Typenum::Pow::powi`.

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -797,6 +797,7 @@ macro_rules! system {
                 }
             }
 
+            std! {
             /// Raises a quantity to an integer power.
             ///
             #[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
@@ -810,22 +811,21 @@ macro_rules! system {
             /// * `E`: `typenum::Integer` power.
             #[inline(always)]
             pub fn powi<E>(
-                self, e: E
+                self, _e: E
             ) -> Quantity<$quantities<$($crate::typenum::Prod<D::$symbol, E>),+>, U, V>
             where
                 $(D::$symbol: $crate::lib::ops::Mul<E>,)+
                 D::Kind: $crate::marker::Mul,
                 E: $crate::typenum::Integer,
-                V: $crate::typenum::Pow<E, Output = V> + $crate::Conversion<V>,
+                V: $crate::num::Float,
             {
                 Quantity {
                     dimension: $crate::lib::marker::PhantomData,
                     units: $crate::lib::marker::PhantomData,
-                    value: $crate::typenum::Pow::powi(self.value, e),
+                    value: self.value.powi(E::to_i32()),
                 }
             }
 
-            std! {
             /// Takes the square root of a number. Returns `NAN` if `self` is a negative
             /// number.
             ///


### PR DESCRIPTION
In Rust 1.45 the upgrade to LLVM 10.0 changes the behavior of
`f{32|64}::powi` on Windows. This commit changes the `Quantity::powi`
implementation to simplify down to `f{32|64}::powi` instead of using
`Typenum::Pow::powi` which uses a less precise algorithm. Resolves #192.

Reviews welcome. Will plan to merge in a couple days.