### PR TITLE
Remove `From`/`Into` impls for `Angle` and `SolidAngle`.

### DIFF
--- a/src/si/angle.rs
+++ b/src/si/angle.rs
@@ -129,38 +129,6 @@ where
     }
 }
 
-mod convert {
-    use super::*;
-
-    impl<U, V> ::lib::convert::From<V> for Angle<U, V>
-    where
-        U: ::si::Units<V> + ?Sized,
-        V: ::num::Num + ::Conversion<V>,
-    {
-        fn from(t: V) -> Self {
-            Angle {
-                dimension: ::lib::marker::PhantomData,
-                units: ::lib::marker::PhantomData,
-                value: t,
-            }
-        }
-    }
-
-    storage_types! {
-        use super::*;
-
-        impl<U> ::lib::convert::From<Angle<U, V>> for V
-        where
-            U: ::si::Units<V> + ?Sized,
-            V: ::num::Num + ::Conversion<V>,
-        {
-            fn from(t: Angle<U, V>) -> Self {
-                t.value
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     storage_types! {
@@ -169,14 +137,6 @@ mod tests {
         use si::angle as a;
         use si::quantities::*;
         use tests::Test;
-
-        #[test]
-        fn from() {
-            let r1: Angle<V> = Angle::<V>::from(V::one());
-            let r2: Angle<V> = V::one().into();
-            let _: V = V::from(r1);
-            let _: V = r2.into();
-        }
 
         #[test]
         fn check_units() {

--- a/src/si/solid_angle.rs
+++ b/src/si/solid_angle.rs
@@ -46,38 +46,6 @@ impl SolidAngle<::si::SI<f64>, f64> {
     };
 }
 
-mod convert {
-    use super::*;
-
-    impl<U, V> ::lib::convert::From<V> for SolidAngle<U, V>
-    where
-        U: ::si::Units<V> + ?Sized,
-        V: ::num::Num + ::Conversion<V>,
-    {
-        fn from(t: V) -> Self {
-            SolidAngle {
-                dimension: ::lib::marker::PhantomData,
-                units: ::lib::marker::PhantomData,
-                value: t,
-            }
-        }
-    }
-
-    storage_types! {
-        use super::*;
-
-        impl<U> ::lib::convert::From<SolidAngle<U, V>> for V
-        where
-            U: ::si::Units<V> + ?Sized,
-            V: ::num::Num + ::Conversion<V>,
-        {
-            fn from(t: SolidAngle<U, V>) -> Self {
-                t.value
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     storage_types! {
@@ -86,14 +54,6 @@ mod tests {
         use si::solid_angle as sa;
         use si::quantities::*;
         use tests::Test;
-
-        #[test]
-        fn from() {
-            let r1: SolidAngle<V> = SolidAngle::<V>::from(V::one());
-            let r2: SolidAngle<V> = V::one().into();
-            let _: V = V::from(r1);
-            let _: V = r2.into();
-        }
 
         #[test]
         fn check_units() {


### PR DESCRIPTION
Impls were problematic because they assume the value is always in
radians. Using explicit conversions that include the unit should be used
instead. Impls were likely added when `Angle` was added and adapted from
`Ratio`. Resolves #188.