### PR TITLE
Change examples to use `Display` instead of `Debug`.

### DIFF
--- a/examples/mks.rs
+++ b/examples/mks.rs
@@ -4,16 +4,15 @@
 extern crate uom;
 
 use length::{foot, meter};
+use uom::fmt::DisplayStyle::Abbreviation;
 
 fn main() {
     let l1 = f32::Length::new::<meter>(100.0);
 
     println!(
-        "{:?} {} = {:?} {}",
-        l1.get::<meter>(),
-        meter::abbreviation(),
-        l1.get::<foot>(),
-        foot::abbreviation()
+        "{} = {}",
+        l1.into_format_args(meter, Abbreviation),
+        l1.into_format_args(foot, Abbreviation)
     );
 }
 

--- a/examples/si.rs
+++ b/examples/si.rs
@@ -2,53 +2,43 @@
 
 extern crate uom;
 
+use uom::fmt::DisplayStyle::Abbreviation;
 use uom::si::f32::*;
 use uom::si::length::{centimeter, kilometer, meter};
 use uom::si::time::second;
 use uom::si::velocity::{kilometer_per_second, meter_per_second};
-use uom::si::Unit;
 
 fn main() {
+    // Setup length and time quantities using different units.
     let l1 = Length::new::<meter>(15.0);
     let l2 = Length::new::<centimeter>(10.0);
     let t1 = Time::new::<second>(50.0);
     let v1 = l1 / t1;
     //let error = l1 + t1; // error[E0308]: mismatched types
 
+    // Setup re-usable format arguments.
+    let m = Length::format_args(meter, Abbreviation);
+    let cm = Length::format_args(centimeter, Abbreviation);
+    let s = Time::format_args(second, Abbreviation);
+
+    // Print results of simple formulas using different output units.
+    println!("{} + {} = {}", m.with(l1), cm.with(l2), m.with(l1 + l2));
     println!(
-        "{:?} {} + {:?} {} = {:?} {}",
-        l1.get::<meter>(),
-        meter::abbreviation(),
-        l2.get::<centimeter>(),
-        centimeter::abbreviation(),
-        (l1 + l2).get::<meter>(),
-        meter::abbreviation()
+        "{} + {} = {}",
+        m.with(l1),
+        cm.with(l2),
+        (l1 + l2).into_format_args(kilometer, Abbreviation)
     );
     println!(
-        "{:?} {} + {:?} {} = {:?} {}",
-        l1.get::<meter>(),
-        meter::abbreviation(),
-        l2.get::<centimeter>(),
-        centimeter::abbreviation(),
-        (l1 + l2).get::<kilometer>(),
-        kilometer::abbreviation()
+        "{} / {} = {}",
+        m.with(l1),
+        s.with(t1),
+        v1.into_format_args(meter_per_second, Abbreviation)
     );
     println!(
-        "{:?} {} / {:?} {} = {:?} {}",
-        l1.get::<meter>(),
-        meter::abbreviation(),
-        t1.get::<second>(),
-        second::abbreviation(),
-        v1.get::<meter_per_second>(),
-        meter_per_second::abbreviation()
-    );
-    println!(
-        "{:?} {} / {:?} {} = {:?} {}",
-        l1.get::<meter>(),
-        meter::abbreviation(),
-        t1.get::<second>(),
-        second::abbreviation(),
-        v1.get::<kilometer_per_second>(),
-        kilometer_per_second::abbreviation()
+        "{} / {} = {}",
+        m.with(l1),
+        s.with(t1),
+        v1.into_format_args(kilometer_per_second, Abbreviation)
     );
 }


### PR DESCRIPTION
mks and si examples are updated to use `format_args` or
`into_format_args` as appropriate so that the `Display` trait can be
used to display quantities in specific units. Part of #123.