### PR TITLE
Implemented Unpin for Quantity types

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -1023,7 +1023,9 @@ macro_rules! system {
             }
         }
 
-        // Safe because our storage type is Unpin
+        // We need to implement this manually because the auto-impl only kicks
+        // in when D, U, and V are Unpin. However because D and U don't exist at
+        // runtime, we only need to ensure V: Unpin.
         impl<D, U, V> $crate::lib::marker::Unpin for Quantity<D, U, V>
         where
             D: Dimension + ?Sized,

--- a/src/system.rs
+++ b/src/system.rs
@@ -1023,6 +1023,14 @@ macro_rules! system {
             }
         }
 
+        // Safe because our storage type is Unpin
+        impl<D, U, V> $crate::lib::marker::Unpin for Quantity<D, U, V>
+        where
+            D: Dimension + ?Sized,
+            U: Units<V> + ?Sized,
+            V: $crate::num::Num + $crate::Conversion<V> + Unpin,
+        {}
+
         autoconvert! {
         impl<D, Ul, Ur, V> $crate::lib::cmp::PartialEq<Quantity<D, Ur, V>> for Quantity<D, Ul, V>
         where

--- a/src/system.rs
+++ b/src/system.rs
@@ -1023,15 +1023,16 @@ macro_rules! system {
             }
         }
 
-        // We need to implement this manually because the auto-impl only kicks
-        // in when D, U, and V are Unpin. However because D and U don't exist at
-        // runtime, we only need to ensure V: Unpin.
+        // Implement Unpin manually because the auto-impl only kicks in when D,
+        // U, and V are Unpin. However because D and U don't exist at runtime,
+        // only V is required to be Unpin.
         impl<D, U, V> $crate::lib::marker::Unpin for Quantity<D, U, V>
         where
             D: Dimension + ?Sized,
             U: Units<V> + ?Sized,
             V: $crate::num::Num + $crate::Conversion<V> + Unpin,
-        {}
+        {
+        }
 
         autoconvert! {
         impl<D, Ul, Ur, V> $crate::lib::cmp::PartialEq<Quantity<D, Ur, V>> for Quantity<D, Ul, V>

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -9,6 +9,8 @@ assert_not_impl_any!(arguments_not_impl; Arguments<Q<Z0, Z0, Z0>, meter>,
     Binary, Debug, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
 assert_impl_all!(display_style; DisplayStyle,
     Clone, Copy);
+assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
+    Clone, Copy, Debug, Display, LowerExp, Unpin, UpperExp);
 
 storage_types! {
     types: Float;

--- a/src/tests/quantities.rs
+++ b/src/tests/quantities.rs
@@ -92,6 +92,15 @@ storage_types! {
             &<degree_fahrenheit as Conversion<V>>::constant(ConstantOp::Add).value());
     }
 
+    #[test]
+    fn all_quantity_types_are_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+
+        assert_unpin::<Length>();
+        assert_unpin::<Mass>();
+        assert_unpin::<ThermodynamicTemperature>();
+    }
+
     #[cfg(feature = "std")]
     #[test]
     fn debug_fmt() {


### PR DESCRIPTION
I believe `Quantity` is `!Unpin` because there's no guarantee the `Dimesion` and `Units` are `Unpin`, however because they don't actually exist at runtime this shouldn't be a problem.

Fixes #204.