### PR TITLE
Increase minimum supported `rustc` version to 1.37.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 sudo: false
 
 rust:
-- 1.31.0    # Oldest supported
+- 1.37.0    # Oldest supported
 - stable
 - beta
 - nightly
@@ -28,19 +28,19 @@ matrix:
       cargo test --verbose --no-run --no-default-features --features "autoconvert usize isize bigint bigrational si std use_serde try-from"
       cargo test --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde try-from"
   - name: Rustfmt
-    rust: 1.38.0
+    rust: 1.46.0
     install:
     - rustup component add rustfmt
     script:
     - cargo fmt -- --check
   - name: Clippy
-    rust: 1.38.0
+    rust: 1.46.0
     install:
     - rustup component add clippy
     script:
     - RUSTFLAGS="-D warnings" cargo clippy --all --tests
   - name: Tarpaulin
-    rust: 1.38.0
+    rust: 1.46.0
     sudo: required
     script:
     - docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin sh -c "cargo build && cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,16 @@ members = [
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
-num-rational = { version = "0.2", optional = true, default-features = false }
-num-bigint = { version = "0.2", optional = true, default-features = false, features = ["std"] }
+num-rational = { version = "0.3", optional = true, default-features = false }
+num-bigint = { version = "0.3", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true, default-features = false }
 typenum = "1.9"
 
 [dev-dependencies]
 approx = "0.3"
-quickcheck = "0.8.5"
+quickcheck = "0.9.2"
 serde_json = "1.0"
-static_assertions = "^0.3.4"
+static_assertions = "1.1"
 
 [features]
 default = ["autoconvert", "f32", "f64", "si", "std"]
@@ -80,7 +80,7 @@ try-from = []
 use_serde = ["serde"]
 # Internal features to include appropriate num-* crates.
 rational-support = ["num-rational"]
-bigint-support = ["num-bigint", "num-rational/bigint"]
+bigint-support = ["num-bigint", "num-rational/num-bigint-std"]
 
 [[example]]
 name = "base"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ uom
 ===
 [![Travis](https://travis-ci.org/iliekturtles/uom.svg?branch=master)](https://travis-ci.org/iliekturtles/uom)
 [![Coveralls](https://coveralls.io/repos/github/iliekturtles/uom/badge.svg?branch=master)](https://coveralls.io/github/iliekturtles/uom?branch=master)
-[![Rustup.rs](https://img.shields.io/badge/rustc-1.31.0%2B-orange.svg)](https://rustup.rs/)
+[![Rustup.rs](https://img.shields.io/badge/rustc-1.37.0%2B-orange.svg)](https://rustup.rs/)
 [![Crates.io](https://img.shields.io/crates/v/uom.svg)](https://crates.io/crates/uom)
 [![Crates.io](https://img.shields.io/crates/l/uom.svg)](https://crates.io/crates/uom)
 [![Documentation](https://img.shields.io/badge/documentation-docs.rs-blue.svg)](https://docs.rs/uom)
@@ -23,7 +23,7 @@ Units of measurement is a crate that does automatic type-safe zero-cost
 [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 
 ## Usage
-`uom` requires `rustc` 1.31.0 or later. Add this to your `Cargo.toml`:
+`uom` requires `rustc` 1.37.0 or later. Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 //!
 //! ## Usage
-//! `uom` requires `rustc` 1.31.0 or later. Add this to your `Cargo.toml`:
+//! `uom` requires `rustc` 1.37.0 or later. Add this to your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]

--- a/src/system.rs
+++ b/src/system.rs
@@ -1539,13 +1539,7 @@ macro_rules! system {
         /// #         }
         /// #     }
         /// mod f32 {
-        ///     mod mks {
-        ///         pub use super::super::*;
-        ///     }
-        ///
-        ///     // `crate::mks` works in Rust 1.30.0 or later. `mod mks {...}` workaround is needed
-        ///     // to support older versions of Rust and the 2018 edition at the same time.
-        ///     Q!(self::mks, f32/*, (centimeter, gram, second)*/);
+        ///     Q!(crate::mks, f32/*, (centimeter, gram, second)*/);
         /// }
         /// # }
         /// ```

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -3,24 +3,22 @@
 use crate::lib::fmt::{Binary, Debug, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex};
 use crate::tests::*;
 
-assert_impl_all!(arguments_impl; Arguments<Q<Z0, Z0, Z0>, meter>,
-    Clone, Copy);
-assert_not_impl_any!(arguments_not_impl; Arguments<Q<Z0, Z0, Z0>, meter>,
-    Binary, Debug, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
-assert_impl_all!(display_style; DisplayStyle,
-    Clone, Copy);
+assert_impl_all!(Arguments<Q<Z0, Z0, Z0>, meter>: Clone, Copy);
+assert_not_impl_any!(Arguments<Q<Z0, Z0, Z0>, meter>: Binary, Debug, Display, LowerExp, LowerHex,
+    Octal, UpperExp, UpperHex);
+assert_impl_all!(DisplayStyle: Clone, Copy);
 
 storage_types! {
     types: Float;
 
     use super::*;
 
-    assert_impl_all!(q; Quantity<Q<Z0, Z0, Z0>, U<V>, V>,
-        Clone, Copy, PartialEq, PartialOrd, Send, Sync);
-    assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Clone, Copy, Debug, Display, LowerExp, UpperExp);
-    assert_not_impl_any!(qa_not_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Binary, LowerHex, Octal, UpperHex);
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>: Clone, Copy, PartialEq, PartialOrd, Send,
+        Sync);
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Clone, Copy, Debug, Display,
+        LowerExp, UpperExp);
+    assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Binary, LowerHex, Octal,
+        UpperHex);
 }
 
 storage_types! {
@@ -28,12 +26,11 @@ storage_types! {
 
     use super::*;
 
-    assert_impl_all!(q; Quantity<Q<Z0, Z0, Z0>, U<V>, V>,
-        Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Send, Sync, crate::lib::hash::Hash);
-    assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Clone, Copy, Binary, Debug, Display, LowerHex, Octal, UpperHex);
-    assert_not_impl_any!(qa_not_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        LowerExp, UpperExp);
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>: Clone, Copy, Eq, Ord, PartialEq, PartialOrd,
+        Send, Sync, crate::lib::hash::Hash);
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Clone, Copy, Binary, Debug,
+        Display, LowerHex, Octal, UpperHex);
+    assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: LowerExp, UpperExp);
 }
 
 storage_types! {
@@ -41,12 +38,11 @@ storage_types! {
 
     use super::*;
 
-    assert_impl_all!(q; Quantity<Q<Z0, Z0, Z0>, U<V>, V>,
-        Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Send, Sync, crate::lib::hash::Hash);
-    assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Clone, Copy, Debug, Display);
-    assert_not_impl_any!(qa_not_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Binary, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>: Clone, Copy, Eq, Ord, PartialEq, PartialOrd,
+        Send, Sync, crate::lib::hash::Hash);
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Clone, Copy, Debug, Display);
+    assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Binary, LowerExp,
+        LowerHex, Octal, UpperExp, UpperHex);
 }
 
 storage_types! {
@@ -54,12 +50,11 @@ storage_types! {
 
     use super::*;
 
-    assert_impl_all!(q; Quantity<Q<Z0, Z0, Z0>, U<V>, V>,
-        Clone, Eq, Ord, PartialEq, PartialOrd, Send, Sync, crate::lib::hash::Hash);
-    assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Clone, Binary, Debug, Display, LowerHex, Octal, UpperHex);
-    assert_not_impl_any!(qa_not_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        LowerExp, UpperExp);
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>: Clone, Eq, Ord, PartialEq, PartialOrd, Send,
+        Sync, crate::lib::hash::Hash);
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Clone, Binary, Debug,
+        Display, LowerHex, Octal, UpperHex);
+    assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: LowerExp, UpperExp);
 }
 
 storage_types! {
@@ -67,10 +62,9 @@ storage_types! {
 
     use super::*;
 
-    assert_impl_all!(q; Quantity<Q<Z0, Z0, Z0>, U<V>, V>,
-        Clone, Eq, Ord, PartialEq, PartialOrd, Send, Sync, crate::lib::hash::Hash);
-    assert_impl_all!(qa_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Clone, Debug, Display);
-    assert_not_impl_any!(qa_not_impl; QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>,
-        Binary, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>: Clone, Eq, Ord, PartialEq, PartialOrd, Send,
+        Sync, crate::lib::hash::Hash);
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Clone, Debug, Display);
+    assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>: Binary, LowerExp,
+        LowerHex, Octal, UpperExp, UpperHex);
 }

--- a/uom-macros/README.md
+++ b/uom-macros/README.md
@@ -2,7 +2,7 @@ uom-macros
 ===
 [![Travis](https://travis-ci.org/iliekturtles/uom.svg?branch=master)](https://travis-ci.org/iliekturtles/uom)
 [![Coveralls](https://coveralls.io/repos/github/iliekturtles/uom/badge.svg?branch=master)](https://coveralls.io/github/iliekturtles/uom?branch=master)
-[![Rustup.rs](https://img.shields.io/badge/rustc-1.31.0%2B-orange.svg)](https://rustup.rs/)
+[![Rustup.rs](https://img.shields.io/badge/rustc-1.37.0%2B-orange.svg)](https://rustup.rs/)
 [![Crates.io](https://img.shields.io/crates/v/uom-macros.svg)](https://crates.io/crates/uom-macros)
 [![Crates.io](https://img.shields.io/crates/l/uom-macros.svg)](https://crates.io/crates/uom-macros)
 [![Documentation](https://img.shields.io/badge/documentation-docs.rs-blue.svg)](https://docs.rs/uom-macros)

--- a/uom-macros/src/lib.rs
+++ b/uom-macros/src/lib.rs
@@ -8,7 +8,7 @@
 // Rustc lints.
 #![forbid(unsafe_code)]
 #![warn(
-    //bare_trait_objects, // Requires rustc 1.27.
+    bare_trait_objects,
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,
@@ -20,9 +20,10 @@
     unused_results
 )]
 
+#[allow(unused_extern_crates)]
 extern crate proc_macro;
 
-use crate::proc_macro::TokenStream;
+use proc_macro::TokenStream;
 
 /// Define a system of quantities.
 #[proc_macro]


### PR DESCRIPTION
 * Update `num-bigint` to 0.3.
 * Update `num-rational` to 0.3.
 * Update `quickcheck` to 0.9.2
 * Update `static_assertions` to 1.1.

`rustc` updated in order to to gain support for the Kleene `?` "at most
one" operator as well as to support the latest version of all
dependencies.