### PR TITLE
Add singular and plural units to from_str impl. #212

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -513,9 +513,7 @@ macro_rules! quantity {
 
                         #[allow(unreachable_patterns)]
                         match unit.trim() {
-                            $($abbreviation => Ok(Self::new::<super::super::$unit>(value)),)+
-                            $($singular => Ok(Self::new::<super::super::$unit>(value)),)+
-                            $($plural => Ok(Self::new::<super::super::$unit>(value)),)+
+                            $($abbreviation | $singular | $plural => Ok(Self::new::<super::super::$unit>(value)),)+
                             _ => Err(UnknownUnit),
                         }
                     }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -508,11 +508,14 @@ macro_rules! quantity {
                     fn from_str(s: &str) -> Result<Self, Self::Err> {
                         let mut parts = s.splitn(2, ' ');
                         let value = parts.next().unwrap();
-                        let abbr = parts.next().ok_or(NoSeparator)?;
+                        let unit = parts.next().ok_or(NoSeparator)?;
                         let value = value.parse::<V>().map_err(|_| ValueParseError)?;
 
-                        match abbr.trim() {
+                        #[allow(unreachable_patterns)]
+                        match unit.trim() {
                             $($abbreviation => Ok(Self::new::<super::super::$unit>(value)),)+
+                            $($singular => Ok(Self::new::<super::super::$unit>(value)),)+
+                            $($plural => Ok(Self::new::<super::super::$unit>(value)),)+
                             _ => Err(UnknownUnit),
                         }
                     }

--- a/src/tests/quantity.rs
+++ b/src/tests/quantity.rs
@@ -38,6 +38,8 @@ storage_types! {
         let m2 = k::Mass::new::<kilogram>(V::from_f64(1.0E-3).unwrap());
 
         Test::assert_eq(&"1 m".parse::<k::Length>().unwrap(), &l1);
+        Test::assert_eq(&"1 meter".parse::<k::Length>().unwrap(), &l1);
+        Test::assert_eq(&"1 meters".parse::<k::Length>().unwrap(), &l1);
         Test::assert_eq(&"1.0 km".parse::<k::Length>().unwrap(), &l2);
         Test::assert_eq(&"1000 kg".parse::<k::Mass>().unwrap(), &m1);
         Test::assert_eq(&"1.0E-3 kg".parse::<k::Mass>().unwrap(), &m2);


### PR DESCRIPTION
This adds the singular and plural unit strings to the match in from_str, which means that strings containing them can be parsed.

I found that there are a number of quantities in uom which have at least one unit where the singular and plural is the same. There is also `pressure`, where pounds-per-square-inch is defined in two different ways. Because of this, the match sometimes includes multiple arms with the same string, resulting in a compiler warning. I've ignored this warning just on the generated match.

I've also updated the tests to check that the expected strings can be parsed.