### PR TITLE
Generate an enum with one variant for each unit, use that for iteration.

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -288,43 +288,41 @@ macro_rules! quantity {
         #[allow(non_camel_case_types)]
         #[non_exhaustive]
         #[derive(Debug, Clone, Copy)]
-        pub enum UnitEnum {
+        pub enum Units {
             $(#[doc=$plural] $unit($unit),)+
         }
-        impl UnitEnum {
+
+        impl Units {
             /// Unit abbreviation.
-            #[inline]
             pub fn abbreviation(&self) -> &'static str {
                 match self {
-                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::abbreviation(),)+
+                    $(Units::$unit(_) => <$unit as super::Unit>::abbreviation(),)+
                 }
             }
 
             /// Unit singular description.
-            #[inline]
             pub fn singular(&self) -> &'static str {
                 match self {
-                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::singular(),)+
+                    $(Units::$unit(_) => <$unit as super::Unit>::singular(),)+
                 }
             }
 
             /// Unit plural description.
-            #[inline]
             pub fn plural(&self) -> &'static str {
                 match self {
-                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::plural(),)+
+                    $(Units::$unit(_) => <$unit as super::Unit>::plural(),)+
                 }
             }
         }
 
-        static ALL_UNIT_ENUMS: &[UnitEnum] = &[
-            $(UnitEnum::$unit($unit),)+
+        static ALL_UNITS: &[Units] = &[
+            $(Units::$unit($unit),)+
         ];
 
         /// Iterate over all defined units for this quantity.
         #[inline]
-        pub fn units() -> impl Iterator<Item=UnitEnum> {
-            ALL_UNIT_ENUMS.iter().copied()
+        pub fn units() -> impl Iterator<Item = Units> {
+            ALL_UNITS.iter().copied()
         }
 
         impl<U, V> $quantity<U, V>

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -320,7 +320,6 @@ macro_rules! quantity {
         ];
 
         /// Iterate over all defined units for this quantity.
-        #[inline]
         pub fn units() -> impl Iterator<Item = Units> {
             ALL_UNITS.iter().copied()
         }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -284,6 +284,49 @@ macro_rules! quantity {
             $description
         }
 
+        /// Unit enum.
+        #[allow(non_camel_case_types)]
+        #[non_exhaustive]
+        #[derive(Debug, Clone, Copy)]
+        pub enum UnitEnum {
+            $(#[doc=$plural] $unit($unit),)+
+        }
+        impl UnitEnum {
+            /// Unit abbreviation.
+            #[inline]
+            pub fn abbreviation(&self) -> &'static str {
+                match self {
+                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::abbreviation(),)+
+                }
+            }
+
+            /// Unit singular description.
+            #[inline]
+            pub fn singular(&self) -> &'static str {
+                match self {
+                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::singular(),)+
+                }
+            }
+
+            /// Unit plural description.
+            #[inline]
+            pub fn plural(&self) -> &'static str {
+                match self {
+                    $(UnitEnum::$unit(_) => <$unit as super::Unit>::plural(),)+
+                }
+            }
+        }
+
+        static ALL_UNIT_ENUMS: &[UnitEnum] = &[
+            $(UnitEnum::$unit($unit),)+
+        ];
+
+        /// Iterate over all defined units for this quantity.
+        #[inline]
+        pub fn units() -> impl Iterator<Item=UnitEnum> {
+            ALL_UNIT_ENUMS.iter().copied()
+        }
+
         impl<U, V> $quantity<U, V>
         where
             U: super::Units<V> + ?Sized,

--- a/src/si/volume.rs
+++ b/src/si/volume.rs
@@ -105,6 +105,19 @@ quantity! {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_volumn_units() {
+        let mut units_iter = crate::si::volume::units();
+
+        // Specifically check the first few units. Doubles as a test of abbreviation() and others
+        assert_eq!("Ym³", units_iter.next().unwrap().abbreviation());
+        assert_eq!("cubic zettameter", units_iter.next().unwrap().singular());
+        assert_eq!("cubic exameters", units_iter.next().unwrap().plural());
+
+        // And there should be 63 remaining units.
+        assert_eq!(63, units_iter.count());
+    }
+
     storage_types! {
         use crate::lib::any::TypeId;
         use crate::num::{FromPrimitive, One};

--- a/src/si/volume.rs
+++ b/src/si/volume.rs
@@ -105,19 +105,6 @@ quantity! {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_volumn_units() {
-        let mut units_iter = crate::si::volume::units();
-
-        // Specifically check the first few units. Doubles as a test of abbreviation() and others
-        assert_eq!("Ym³", units_iter.next().unwrap().abbreviation());
-        assert_eq!("cubic zettameter", units_iter.next().unwrap().singular());
-        assert_eq!("cubic exameters", units_iter.next().unwrap().plural());
-
-        // And there should be 63 remaining units.
-        assert_eq!(63, units_iter.count());
-    }
-
     storage_types! {
         use crate::lib::any::TypeId;
         use crate::num::{FromPrimitive, One};

--- a/src/tests/quantity.rs
+++ b/src/tests/quantity.rs
@@ -180,6 +180,19 @@ storage_types! {
             a == b && a == c
         }
     }
+
+    #[test]
+    fn test_units_iterator() {
+        let mut units_iter = crate::si::volume::units();
+
+        // Specifically check the first few units. Doubles as a test of abbreviation() and others
+        assert_eq!("Ym³", units_iter.next().unwrap().abbreviation());
+        assert_eq!("cubic zettameter", units_iter.next().unwrap().singular());
+        assert_eq!("cubic exameters", units_iter.next().unwrap().plural());
+
+        // And there should be 63 remaining units.
+        assert_eq!(63, units_iter.count());
+    }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This extends the `quantity!` macro to generate a non-exhaustive enum with one variant per unit. A static slice of the different potential values of this enum is also generated, which is exposed publicly through a `units()` function, which returns an iterator. This can be used to iterate over the different units.