### PR TITLE
Ensure `UnwindSafe` and `RefUnwindSafe` are implemented.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,15 @@ pub mod lib {
         pub use std::ops::*;
         pub use typenum::type_operators::*;
     }
+
+    // Export `panic` module when the `std` feature is not enabled. `RefUnwindSafe` and `UnwindSafe`
+    // traits do not exist in `core` but are conditionally needed in traits defined by `uom` when
+    // `std` is enabled. These definitions work around conditional requirements.
+    #[cfg(not(feature = "std"))]
+    pub mod panic {
+        pub trait RefUnwindSafe {}
+        pub trait UnwindSafe {}
+    }
 }
 
 // Conditionally import num sub-crate types based on feature selection.

--- a/src/system.rs
+++ b/src/system.rs
@@ -124,7 +124,13 @@ macro_rules! system {
         /// [quantity]: http://jcgm.bipm.org/vim/en/1.1.html
         /// [base]: http://jcgm.bipm.org/vim/en/1.4.html
         /// [quantities]: http://jcgm.bipm.org/vim/en/1.3.html
-        pub trait Dimension: Send + Sync {
+        pub trait Dimension:
+            Send
+            + Sync
+            + Unpin
+            + $crate::lib::panic::RefUnwindSafe
+            + $crate::lib::panic::UnwindSafe
+        {
             $($(#[$name_attr])*
             ///
             /// Quantity dimension.
@@ -144,7 +150,12 @@ macro_rules! system {
         /// [units]: http://jcgm.bipm.org/vim/en/1.13.html
         /// [base]: http://jcgm.bipm.org/vim/en/1.10.html
         /// [quantities]: http://jcgm.bipm.org/vim/en/1.3.html
-        pub trait Units<V>: Send + Sync
+        pub trait Units<V>:
+            Send
+            + Sync
+            + Unpin
+            + $crate::lib::panic::RefUnwindSafe
+            + $crate::lib::panic::UnwindSafe
         where
             V: $crate::Conversion<V>,
         {
@@ -1030,17 +1041,6 @@ macro_rules! system {
             }
         }
 
-        // Implement Unpin manually because the auto-impl only kicks in when D,
-        // U, and V are Unpin. However because D and U don't exist at runtime,
-        // only V is required to be Unpin.
-        impl<D, U, V> $crate::lib::marker::Unpin for Quantity<D, U, V>
-        where
-            D: Dimension + ?Sized,
-            U: Units<V> + ?Sized,
-            V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::marker::Unpin,
-        {
-        }
-
         autoconvert! {
         impl<D, Ul, Ur, V> $crate::lib::cmp::PartialEq<Quantity<D, Ur, V>> for Quantity<D, Ul, V>
         where
@@ -1424,13 +1424,6 @@ macro_rules! system {
             {
             }
 
-            impl<D, N> $crate::lib::marker::Unpin for Arguments<D, N>
-            where
-                D: Dimension + ?Sized,
-                N: Unit + $crate::lib::marker::Unpin,
-            {
-            }
-
             impl<D, U, V, N> $crate::lib::clone::Clone for QuantityArguments<D, U, V, N>
             where
                 D: Dimension + ?Sized,
@@ -1452,15 +1445,6 @@ macro_rules! system {
                 U: Units<V> + ?Sized,
                 V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::marker::Copy,
                 N: Unit,
-            {
-            }
-
-            impl<D, U, V, N> $crate::lib::marker::Unpin for QuantityArguments<D, U, V, N>
-            where
-                D: Dimension + ?Sized,
-                U: Units<V> + ?Sized,
-                V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::marker::Unpin,
-                N: Unit + $crate::lib::marker::Unpin,
             {
             }
 

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -3,16 +3,25 @@
 use crate::lib::fmt::{Binary, Debug, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex};
 use crate::lib::hash::Hash;
 use crate::lib::marker::Unpin;
+#[cfg(feature = "std")]
+use crate::lib::panic::{RefUnwindSafe, UnwindSafe};
 use crate::tests::*;
 
 assert_impl_all!(Arguments<Q<Z0, Z0, Z0>, meter>:
     Clone, Copy, Send, Sync, Unpin);
+#[cfg(feature = "std")]
+assert_impl_all!(Arguments<Q<Z0, Z0, Z0>, meter>:
+    RefUnwindSafe, UnwindSafe);
 assert_not_impl_any!(Arguments<Q<Z0, Z0, Z0>, meter>:
     Binary, Debug, Display, Eq, Hash, LowerExp, LowerHex, Octal, Ord, PartialEq, PartialOrd,
     UpperExp, UpperHex);
 #[rustfmt::skip]
 assert_impl_all!(DisplayStyle:
     Clone, Copy, Debug, Send, Sync, Unpin);
+#[cfg(feature = "std")]
+#[rustfmt::skip]
+assert_impl_all!(DisplayStyle:
+    RefUnwindSafe, UnwindSafe);
 #[rustfmt::skip]
 assert_not_impl_any!(DisplayStyle:
     Binary, Display, Eq, Hash, LowerExp, LowerHex, Ord, Octal, PartialEq, PartialOrd, UpperExp,
@@ -20,6 +29,10 @@ assert_not_impl_any!(DisplayStyle:
 #[rustfmt::skip]
 assert_impl_all!(ParseQuantityError:
     Clone, Debug, Display, Eq, PartialEq, Send, Sync, Unpin);
+#[cfg(feature = "std")]
+#[rustfmt::skip]
+assert_impl_all!(ParseQuantityError:
+    RefUnwindSafe, UnwindSafe);
 #[rustfmt::skip]
 assert_not_impl_any!(ParseQuantityError:
     Binary, Copy, Hash, LowerExp, LowerHex, Ord, Octal, PartialOrd, UpperExp, UpperHex);
@@ -31,10 +44,16 @@ storage_types! {
 
     assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Clone, Copy, Debug, PartialEq, PartialOrd, Send, Sync, Unpin);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Binary, Display, Eq, Hash, LowerExp, LowerHex, Octal, Ord, UpperExp, UpperHex);
     assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Clone, Copy, Debug, Display, LowerExp, Send, Sync, Unpin, UpperExp);
+    #[cfg(feature = "std")]
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Eq, Hash, LowerHex, Octal, Ord, PartialEq, PartialOrd, UpperHex);
 }
@@ -46,11 +65,17 @@ storage_types! {
 
     assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Send, Sync, Unpin);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Binary, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
     assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Clone, Copy, Debug, Display, LowerExp, LowerHex, Octal, Send, Sync, Unpin, UpperExp,
         UpperHex);
+    #[cfg(feature = "std")]
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Eq, Hash, Ord, PartialEq, PartialOrd);
 }
@@ -62,11 +87,17 @@ storage_types! {
 
     assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Send, Sync, Unpin);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Binary, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
     assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Clone, Copy, Debug, Display, LowerExp, LowerHex, Octal, Send, Sync, Unpin, UpperExp,
         UpperHex);
+    #[cfg(feature = "std")]
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Eq, Hash, Ord, PartialEq, PartialOrd);
 }
@@ -78,10 +109,16 @@ storage_types! {
 
     assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Send, Sync, Unpin);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Binary, Copy, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
     assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Clone, Debug, Display, LowerHex, Octal, Send, Sync, Unpin, UpperHex);
+    #[cfg(feature = "std")]
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Copy, Eq, Hash, LowerExp, Ord, PartialEq, PartialOrd, UpperExp);
 }
@@ -93,10 +130,16 @@ storage_types! {
 
     assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Send, Sync, Unpin);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
         Binary, Copy, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
     assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Clone, Debug, Display, LowerHex, Octal, Send, Sync, Unpin, UpperHex);
+    #[cfg(feature = "std")]
+    assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+        RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Copy, Eq, Hash, LowerExp, Ord, PartialEq, PartialOrd, UpperExp);
 }


### PR DESCRIPTION
This fix also simplifies ensuring that `Unpin` is implemented by using
trait inheritance instead of explicit impls.

@DusterTheFirst, if you could test with your code I would great appreciate it.