### PR TITLE
Resolve now-ambiguous trait bounts in non-`autoconvert` code.

### DIFF
--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -286,6 +286,13 @@ pub mod marker {
                     V,
                 >
             where
+                L: crate::typenum::Integer,
+                M: crate::typenum::Integer,
+                T: crate::typenum::Integer,
+                I: crate::typenum::Integer,
+                Th: crate::typenum::Integer,
+                N: crate::typenum::Integer,
+                J: crate::typenum::Integer,
                 U: Units<V> + ?Sized,
                 V: crate::num_traits::Num + crate::Conversion<V>,
             {

--- a/src/system.rs
+++ b/src/system.rs
@@ -482,7 +482,8 @@ macro_rules! system {
                     for Quantity<Dl, U, V>
                 where
                     Dl: Dimension + ?Sized,
-                    $(Dl::$symbol: $crate::lib::ops::$AddSubTrait<Dr::$symbol>,)+
+                    $(Dl::$symbol: $crate::lib::ops::$AddSubTrait<Dr::$symbol>,
+                    <Dl::$symbol as $crate::lib::ops::$AddSubTrait<Dr::$symbol>>::Output: $crate::typenum::Integer,)+
                     Dl::Kind: $crate::marker::$MulDivTrait,
                     Dr: Dimension + ?Sized,
                     Dr::Kind: $crate::marker::$MulDivTrait,


### PR DESCRIPTION
`autoconvert` code fixed in 2f6d6c8995e346512b1837d8fdd32cf7df8df033.
Resolves #234, #210.