### PR TITLE
Rustdoc warnings

### DIFF
--- a/.github/workflows/ci-tool-checks.yml
+++ b/.github/workflows/ci-tool-checks.yml
@@ -1,4 +1,4 @@
-name: CI - Clippy, Rustfmt, & Tarpaulin
+name: CI - Clippy, Rustfmt, Rustdoc, & Tarpaulin
 on: [pull_request, push]
 
 jobs:
@@ -47,6 +47,14 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+      - name: Rustdoc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all --no-deps
+        env:
+          RUSTDOCFLAGS: '-D warnings'
 
       - name: Run tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ autotests = true
 autobenches = true
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "try-from", "use_serde"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -3,8 +3,8 @@
 /// the `FromStr` implementation. Using this macro will create submodules for the underlying storage
 /// types that are enabled (e.g. `mod f32`). `@...` match arms are considered private.
 ///
-/// When using the pre-built [SI](si) system included with `uom` this macro allows for new units to
-/// quickly be defined without requiring a release. [Pull requests](pr) to add new units upstream
+/// When using the pre-built [SI][si] system included with `uom` this macro allows for new units to
+/// quickly be defined without requiring a release. [Pull requests][pr] to add new units upstream
 /// area always greatly appreciated.
 ///
 /// * `$system`: Path to the module where the [`system!`](macro.system.html) macro was run (e.g.
@@ -97,9 +97,7 @@
 /// ```
 ///
 /// [si]: http://jcgm.bipm.org/vim/en/1.16.html
-/// [quantity]: http://jcgm.bipm.org/vim/en/1.1.html
 /// [measurement]: http://jcgm.bipm.org/vim/en/1.9.html
-/// [kind]: https://jcgm.bipm.org/vim/en/1.2.html
 /// [pr]: https://github.com/iliekturtles/uom/pulls
 #[macro_export]
 macro_rules! unit {


### PR DESCRIPTION
Run `rustdoc` as part of CI and resolve errors.