### PR TITLE
RFC: Add a zero constant to quantities based on primitive types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,6 +456,20 @@ pub trait ConversionFactor<V>:
     fn value(self) -> V;
 }
 
+/// Helper trait to identify the zero value of a type at compile time.
+///
+#[cfg_attr(all(feature = "si", feature = "f32"), doc = " ```rust")]
+#[cfg_attr(not(all(feature = "si", feature = "f32")), doc = " ```rust,ignore")]
+/// # use uom::si::f32::Length;
+/// use uom::ConstZero;
+///
+/// const ORIGIN: (Length, Length, Length) = (Length::ZERO, Length::ZERO, Length::ZERO);
+/// ```
+pub trait ConstZero {
+    /// Constant representing the zero value.
+    const ZERO: Self;
+}
+
 /// Default [kind][kind] of quantities to allow addition, subtraction, multiplication, division,
 /// remainder, negation, and saturating addition/subtraction.
 ///
@@ -507,6 +521,10 @@ storage_types! {
             self
         }
     }
+
+    impl crate::ConstZero for V {
+        const ZERO: Self = 0.0;
+    }
 }
 
 storage_types! {
@@ -531,6 +549,10 @@ storage_types! {
         fn value(self) -> V {
             self.to_integer()
         }
+    }
+
+    impl crate::ConstZero for V {
+        const ZERO: Self = 0;
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -1288,6 +1288,19 @@ macro_rules! system {
             }
         }
 
+        impl<D, U, V> $crate::ConstZero for Quantity<D, U, V>
+        where
+            D: Dimension + ?Sized,
+            U: Units<V> + ?Sized,
+            V: $crate::num::Num + $crate::Conversion<V> + $crate::ConstZero,
+        {
+            const ZERO: Self = Self {
+                dimension: $crate::lib::marker::PhantomData,
+                units: $crate::lib::marker::PhantomData,
+                value: V::ZERO,
+            };
+        }
+
         serde! {
         impl<D, U, V> $crate::serde::Serialize for Quantity<D, U, V>
         where


### PR DESCRIPTION
The public helper trait is a bit cumbersome but it appears to be the most straight-forward way to construct a zero value in const context.

An alternative that avoid the intermediate trait this would be to implement something like
```rust
impl<U> $quantity<U, $type>
where
    U: __system::Units<$type> + ?Sized,
{
    /// Constant representing the zero value.
    pub const ZERO: Self = Self {
        dimension: $crate::lib::marker::PhantomData,
        units: $crate::lib::marker::PhantomData,
        value: 0 as $type,
    };
}
```
for the same set of primitive types.

Fixes #26