### PR TITLE
Update dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ members = [
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
-num-rational = { version = "0.3", optional = true, default-features = false }
-num-bigint = { version = "0.3", optional = true, default-features = false, features = ["std"] }
+num-rational = { version = "0.4", optional = true, default-features = false }
+num-bigint = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true, default-features = false }
-typenum = "1.9"
+typenum = "1.13"
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ pub mod num {
     pub use num_bigint::{BigInt, BigUint};
 
     #[cfg(feature = "rational-support")]
-    pub use num_rational::Rational;
+    pub type Rational = num_rational::Ratio<isize>;
 
     #[cfg(feature = "bigint-support")]
     pub use num_rational::BigRational;


### PR DESCRIPTION
There's a bunch of warning about deprecate use of Rational but everything compile fine and i have seen no regression in test on my computer.