### PR TITLE
Deny `rustc` warnings during full test suite and min test matrix.

### DIFF
--- a/.github/workflows/ci-full-test-suite.yml
+++ b/.github/workflows/ci-full-test-suite.yml
@@ -5,6 +5,8 @@ jobs:
   full_test_suite:
     name: Run full test suite (Rust stable on ubuntu-latest)
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-min-test-matrix.yml
+++ b/.github/workflows/ci-min-test-matrix.yml
@@ -5,6 +5,8 @@ jobs:
   min_test_matrix:
     name: Run minimal test matrix (Rust ${{ matrix.rust }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -D warnings
 
     strategy:
       fail-fast: false # If one job fails, run remaining jobs.


### PR DESCRIPTION
`RUSTFLAGS="-D warnings"` is set in both workflows to ensure that
`rustc` warnings and caught and fail the respective workflows.