### PR TITLE
Update quickcheck

### DIFF
--- a/.github/workflows/ci-full-test-suite.yml
+++ b/.github/workflows/ci-full-test-suite.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --verbose --features "use_serde try-from"
+          args: --all --verbose --features "use_serde"
 
       - name: Test si
         uses: actions-rs/cargo@v1
@@ -48,16 +48,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --no-default-features --features "autoconvert f32 si use_serde try-from"
+          args: --verbose --no-default-features --features "autoconvert f32 si use_serde"
 
       - name: Test si with underlying storage types
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --no-run --no-default-features --features "autoconvert usize isize bigint bigrational si std use_serde try-from"
+          args: --verbose --no-run --no-default-features --features "autoconvert usize isize bigint bigrational si std use_serde"
 
       - name: Test all non-si features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde try-from"
+          args: --verbose --no-run --no-default-features --features "autoconvert usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 bigint biguint rational rational32 rational64 bigrational f32 f64 std use_serde"

--- a/.github/workflows/ci-min-test-matrix.yml
+++ b/.github/workflows/ci-min-test-matrix.yml
@@ -42,4 +42,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --verbose --features "use_serde try-from"
+          args: --all --verbose --features "use_serde"

--- a/.github/workflows/ci-min-test-matrix.yml
+++ b/.github/workflows/ci-min-test-matrix.yml
@@ -19,7 +19,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.37.0  # MSRV
+          - 1.43.0  # MSRV
         exclude:
           - os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ autobenches = true
 [package.metadata.docs.rs]
 features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "try-from", "use_serde"]
 
+[package.metadata]
+msrv = "1.43.0"
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ typenum = "1.13"
 
 [dev-dependencies]
 approx = "0.5"
-quickcheck = "0.9.2"
+quickcheck = "1.0"
 serde_json = "1.0"
 static_assertions = "1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ autotests = true
 autobenches = true
 
 [package.metadata.docs.rs]
-features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "try-from", "use_serde"]
+features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "use_serde"]
 
 [package.metadata]
 msrv = "1.43.0"
@@ -70,9 +70,8 @@ f32 = []
 f64 = []
 si = []
 std = ["num-traits/std"]
-# The `try-from` feature provides `impl TryFrom<Time> for Duration` and `impl TryFrom<Duration> for
-# Time`. The `TryFrom` trait was stabilized in Rust 1.34.0 and will cause uom to fail to compile if
-# enabled with an earlier version of Rust.
+# The try-from feature is deprecated and will be removed in a future release of uom. Functionality
+# previously exposed by the feature is now enabled by default.
 try-from = []
 # The `use_serde` feature exists so that, in the future, other dependency features like num/serde
 # can be added. However, num/serde is currently left out because it has not yet been updated to

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ uom = {
         "rational", "rational32", "rational64", "bigrational", # Integer ratio storage types.
         "f32", "f64", # Floating point storage types.
         "si", "std", # Built-in SI system and std library support.
-        "try-from", # `TryFrom` support between `Time` and `Duration`. Requires `rustc` 1.34.0.
         "use_serde", # Serde support.
     ]
 }
@@ -108,8 +107,6 @@ uom = {
    default.
  * `std` -- Feature to compile with standard library support. Disabling this feature compiles `uom`
    with `no_std`. Enabled by default.
- * `try-from` -- Feature to enable `TryFrom` support between `Time` and `Duration`. Requires `rustc`
-   1.34.0.
  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
    with the [Serde][serde] crate. Disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ uom
 ===
 [![Github Actions](https://img.shields.io/github/workflow/status/iliekturtles/uom/CI%20-%20full%20test%20suite/master?label=build)](https://github.com)
 [![Codecov.io](https://img.shields.io/codecov/c/github/iliekturtles/uom/master)](https://codecov.io/gh/iliekturtles/uom)
-[![Rustup.rs](https://img.shields.io/badge/rustc-1.37.0%2B-orange.svg)](https://rustup.rs/)
+[![Rustup.rs](https://img.shields.io/badge/rustc-1.43.0%2B-orange.svg)](https://rustup.rs/)
 [![Crates.io](https://img.shields.io/crates/v/uom.svg)](https://crates.io/crates/uom)
 [![Crates.io](https://img.shields.io/crates/l/uom.svg)](https://crates.io/crates/uom)
 [![Documentation](https://img.shields.io/badge/documentation-docs.rs-blue.svg)](https://docs.rs/uom)
@@ -23,7 +23,7 @@ Units of measurement is a crate that does automatic type-safe zero-cost
 [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 
 ## Usage
-`uom` requires `rustc` 1.37.0 or later. Add this to your `Cargo.toml`:
+`uom` requires `rustc` 1.43.0 or later. Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! [orbiter]: https://en.wikipedia.org/wiki/Mars_Climate_Orbiter
 //!
 //! ## Usage
-//! `uom` requires `rustc` 1.37.0 or later. Add this to your `Cargo.toml`:
+//! `uom` requires `rustc` 1.43.0 or later. Add this to your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@
 //!         "rational", "rational32", "rational64", "bigrational", # Integer ratio storage types.
 //!         "f32", "f64", # Floating point storage types.
 //!         "si", "std", # Built-in SI system and std library support.
-//!         "try-from", # `TryFrom` support between `Time` and `Duration`. Requires `rustc` 1.34.0.
 //!         "use_serde", # Serde support.
 //!     ]
 //! }
@@ -96,8 +95,6 @@
 //!    default.
 //!  * `std` -- Feature to compile with standard library support. Disabling this feature compiles
 //!    `uom` with `no_std`. Enabled by default.
-//!  * `try-from` -- Feature to enable `TryFrom` support between `Time` and `Duration`. Requires
-//!    `rustc` 1.34.0.
 //!  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
 //!    with the [Serde][serde] crate. Disabled by default.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,8 +438,10 @@ pub trait Conversion<V> {
 /// * `V`: Underlying storage type trait is implemented for.
 ///
 /// [factor]: https://jcgm.bipm.org/vim/en/1.24.html
+#[allow(unused_qualifications)] // lib:cmp::PartialOrder false positive.
 pub trait ConversionFactor<V>:
-    lib::ops::Add<Self, Output = Self>
+    lib::cmp::PartialOrd
+    + lib::ops::Add<Self, Output = Self>
     + lib::ops::Sub<Self, Output = Self>
     + lib::ops::Mul<Self, Output = Self>
     + lib::ops::Div<Self, Output = Self>

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -161,33 +161,29 @@ mod tests {
             use crate::si::quantities::*;
             use crate::tests::Test;
 
-            fn test_nan_or_eq(yl: V, yr: V) -> bool {
-                (yl.is_nan() && yr.is_nan()) || Test::eq(&yl, &yr)
-            }
-
             quickcheck! {
                 fn acos(x: V) -> bool {
-                    test_nan_or_eq(x.acos(), Ratio::from(x).acos().get::<a::radian>())
+                    Test::eq(&x.acos(), &Ratio::from(x).acos().get::<a::radian>())
                 }
 
                 fn acosh(x: V) -> bool {
-                    test_nan_or_eq(x.acosh(), Ratio::from(x).acosh().get::<a::radian>())
+                    Test::eq(&x.acosh(), &Ratio::from(x).acosh().get::<a::radian>())
                 }
 
                 fn asin(x: V) -> bool {
-                    test_nan_or_eq(x.asin(), Ratio::from(x).asin().get::<a::radian>())
+                    Test::eq(&x.asin(), &Ratio::from(x).asin().get::<a::radian>())
                 }
 
                 fn asinh(x: V) -> bool {
-                    test_nan_or_eq(x.asinh(), Ratio::from(x).asinh().get::<a::radian>())
+                    Test::eq(&x.asinh(), &Ratio::from(x).asinh().get::<a::radian>())
                 }
 
                 fn atan(x: V) -> bool {
-                    test_nan_or_eq(x.atan(), Ratio::from(x).atan().get::<a::radian>())
+                    Test::eq(&x.atan(), &Ratio::from(x).atan().get::<a::radian>())
                 }
 
                 fn atanh(x: V) -> bool {
-                    test_nan_or_eq(x.atanh(), Ratio::from(x).atanh().get::<a::radian>())
+                    Test::eq(&x.atanh(), &Ratio::from(x).atanh().get::<a::radian>())
                 }
             }
         }

--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -1,8 +1,6 @@
 //! Time (base unit second, s).
 
-#[cfg(feature = "try-from")]
 use crate::lib::time::Duration;
-#[cfg(feature = "try-from")]
 use crate::num::{FromPrimitive, ToPrimitive, Zero};
 
 quantity! {
@@ -58,7 +56,6 @@ quantity! {
 }
 
 /// An error encountered converting between `Time` and `Duration`.
-#[cfg(feature = "try-from")]
 #[derive(Debug, Clone, Copy)]
 pub enum TryFromError {
     /// The given time interval was negative, making conversion to a duration nonsensical.
@@ -81,7 +78,6 @@ pub enum TryFromError {
 /// underlying storage type or avoiding the conversion altogether.
 ///
 /// [TryFromError]: enum.TryFromError.html
-#[cfg(feature = "try-from")]
 impl<U, V> crate::lib::convert::TryFrom<Time<U, V>> for Duration
 where
     U: crate::si::Units<V> + ?Sized,
@@ -117,7 +113,6 @@ where
 /// different underlying storage type or avoiding the conversion altogether.
 ///
 /// [TryFromError]: enum.TryFromError.html
-#[cfg(feature = "try-from")]
 impl<U, V> crate::lib::convert::TryFrom<Duration> for Time<U, V>
 where
     U: crate::si::Units<V> + ?Sized,
@@ -140,7 +135,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "try-from"))]
+#[cfg(test)]
 mod tests {
     storage_types! {
         types: PrimInt, BigInt, BigUint, Float;

--- a/tests/edition_check/Cargo.toml
+++ b/tests/edition_check/Cargo.toml
@@ -9,4 +9,3 @@ uom = { path = "../.." }
 [features]
 default = []
 use_serde = ["uom/use_serde"]
-try-from = ["uom/try-from"]

--- a/tests/feature_check/Cargo.toml
+++ b/tests/feature_check/Cargo.toml
@@ -8,4 +8,3 @@ uom = { path = "../.." }
 [features]
 default = []
 use_serde = ["uom/use_serde"]
-try-from = ["uom/try-from"]

--- a/uom-macros/README.md
+++ b/uom-macros/README.md
@@ -2,7 +2,7 @@ uom-macros
 ===
 [![Travis](https://travis-ci.org/iliekturtles/uom.svg?branch=master)](https://travis-ci.org/iliekturtles/uom)
 [![Coveralls](https://coveralls.io/repos/github/iliekturtles/uom/badge.svg?branch=master)](https://coveralls.io/github/iliekturtles/uom?branch=master)
-[![Rustup.rs](https://img.shields.io/badge/rustc-1.37.0%2B-orange.svg)](https://rustup.rs/)
+[![Rustup.rs](https://img.shields.io/badge/rustc-1.43.0%2B-orange.svg)](https://rustup.rs/)
 [![Crates.io](https://img.shields.io/crates/v/uom-macros.svg)](https://crates.io/crates/uom-macros)
 [![Crates.io](https://img.shields.io/crates/l/uom-macros.svg)](https://crates.io/crates/uom-macros)
 [![Documentation](https://img.shields.io/badge/documentation-docs.rs-blue.svg)](https://docs.rs/uom-macros)


### PR DESCRIPTION
Update to the latest version. Requires fixing floating point precision issues since the latest version of quickcheck provides a better range of values that weren't seen before. Will also require bumping the MSRV.