### PR TITLE
Allow parsing quantities without a separator between value and unit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,9 +658,6 @@ pub mod str {
     #[allow(missing_copy_implementations)]
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub enum ParseQuantityError {
-        /// No separators (spaces) were encountered.
-        NoSeparator,
-
         /// An error occurred while parsing the value (first) portion of the string.
         ///
         /// Due to exhaustiveness and type system limitations, this variant does not encode
@@ -680,7 +677,6 @@ pub mod str {
             use ParseQuantityError::*;
 
             match *self {
-                NoSeparator => write!(f, "no space between quantity and units"),
                 ValueParseError => write!(f, "error parsing unit quantity"),
                 UnknownUnit => write!(f, "unrecognized unit of measure"),
             }

--- a/src/tests/quantity.rs
+++ b/src/tests/quantity.rs
@@ -38,13 +38,17 @@ storage_types! {
         let m2 = k::Mass::new::<kilogram>(V::from_f64(1.0E-3).unwrap());
 
         Test::assert_eq(&"1 m".parse::<k::Length>().unwrap(), &l1);
+        Test::assert_eq(&"1m".parse::<k::Length>().unwrap(), &l1);
         Test::assert_eq(&"1 meter".parse::<k::Length>().unwrap(), &l1);
+        Test::assert_eq(&"1meter".parse::<k::Length>().unwrap(), &l1);
         Test::assert_eq(&"1 meters".parse::<k::Length>().unwrap(), &l1);
+        Test::assert_eq(&"1meters".parse::<k::Length>().unwrap(), &l1);
         Test::assert_eq(&"1.0 km".parse::<k::Length>().unwrap(), &l2);
+        Test::assert_eq(&"1.0km".parse::<k::Length>().unwrap(), &l2);
         Test::assert_eq(&"1000 kg".parse::<k::Mass>().unwrap(), &m1);
+        Test::assert_eq(&"1000kg".parse::<k::Mass>().unwrap(), &m1);
         Test::assert_eq(&"1.0E-3 kg".parse::<k::Mass>().unwrap(), &m2);
 
-        assert_eq!(&"1m".parse::<k::Length>(), &Err(ParseQuantityError::NoSeparator));
         assert_eq!(&"10k m".parse::<k::Length>(), &Err(ParseQuantityError::ValueParseError));
         assert_eq!(&"1,000 km".parse::<k::Length>(), &Err(ParseQuantityError::ValueParseError));
         assert_eq!(&"10 s".parse::<k::Length>(), &Err(ParseQuantityError::UnknownUnit));


### PR DESCRIPTION
## Summary
This PR allows uom to read quantities from a string even if it does not contain a space between value and unit.

## Rationale
I was trying to read some SI units from the command line.  The current implementation of `Quantity::from_str` requires a space between value and unit, e.g. `3 kg` will parse properly but `3kg` will not.
But command lines tend to break arguments at whitespace, so reading in `3 kg` would mean I'd have to read in two arguments ("3" and "kg") and then merge them to let uom parse them. Or I could force every user of my program to quote the input, e.g. `$ ./my_prog --weight "3 kg"` instead of `./my_prog --weight 3 kg`.

Or I could accept `./my_prog --weight 3kg`. I believe this could be helpful for more than just my situation, as evidenced by previous issues like #163 or #212. So, I've made this pull request.

## Changes
 - Edit the implementation of `FromStr` for `quantity!` to cope with strings with no space as a fall-back.
     + If there is a space, the algorithm proceeds as before.
     + If there isn't, the quantity is expressed as only one word. The algorithm tries to remove each unit from the string.
     + If this succeeds and the remaining string can be parsed as a number, we have retrieved the correct unit and value, so the algorithm can return the appropriate quantity as if there was a space to begin with.
 - Remove the `NoSeparator` variant from `ParseQuantityError` because is does not have any purpose anymore if the omitted space is not an error anymore.
 - Edit the unit tests to expect everything that worked with a space before to also work without a space.

p.s.> Nice and very handy crate. Thank you for all the work that went into it!