### PR TITLE
Implement and test `exp` for Ratio

### DIFF
--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -32,13 +32,14 @@ quantity! {
     }
 }
 
-/// Implementation of various stdlib inverse trigonometric functions
+/// Implementation of various stdlib functions.
 #[cfg(feature = "std")]
 impl<U, V> Ratio<U, V>
 where
     U: crate::si::Units<V> + ?Sized,
     V: crate::num::Float + crate::Conversion<V>,
     radian: crate::Conversion<V, T = V::T>,
+    ratio: crate::Conversion<V, T = V::T>,
 {
     /// Computes the value of the inverse cosine of the ratio.
     #[inline(always)]
@@ -75,16 +76,7 @@ where
     pub fn atanh(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.atanh())
     }
-}
 
-/// Implementation of various stdlib exponentiation and logarithm functions
-#[cfg(feature = "std")]
-impl<U, V> Ratio<U, V>
-where
-    U: crate::si::Units<V> + ?Sized,
-    V: crate::num::Float + crate::Conversion<V>,
-    ratio: crate::Conversion<V, T = V::T>,
-{
     /// Returns `e^(self)`, (the exponential function).
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
@@ -169,11 +161,12 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
-    mod inv_trig {
+    mod float {
         storage_types! {
             types: Float;
 
             use crate::si::angle as a;
+            use crate::si::ratio as r;
             use crate::si::quantities::*;
             use crate::tests::Test;
 
@@ -201,20 +194,7 @@ mod tests {
                 fn atanh(x: V) -> bool {
                     Test::eq(&x.atanh(), &Ratio::from(x).atanh().get::<a::radian>())
                 }
-            }
-        }
-    }
 
-    #[cfg(feature = "std")]
-    mod exp_and_log {
-        storage_types! {
-            types: Float;
-
-            use crate::si::ratio as r;
-            use crate::si::quantities::*;
-            use crate::tests::Test;
-
-            quickcheck! {
                 fn exp(x: V) -> bool {
                     Test::eq(&x.exp(), &Ratio::from(x).exp().get::<r::ratio>())
                 }

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -83,6 +83,49 @@ where
     pub fn exp(self) -> Ratio<U, V> {
         Ratio::new::<ratio>(self.value.exp())
     }
+
+    /// Returns 2^(self).
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn exp2(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.exp2())
+    }
+
+    /// Returns the natural logarithm of the number.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn ln(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.ln())
+    }
+
+    /// Returns the base 2 logarithm of the number.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn log2(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.log2())
+    }
+
+    /// Returns the base 10 logarithm of the number.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn log10(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.log10())
+    }
+
+    /// Returns e^(self) - 1 in a way that is accurate even if the number is close to zero.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn exp_m1(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.exp_m1())
+    }
+
+    /// Returns ln(1+n) (natural logarithm) more accurately than if the
+    /// operations were performed separately.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn ln_1p(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.ln_1p())
+    }
 }
 
 mod convert {
@@ -197,6 +240,30 @@ mod tests {
 
                 fn exp(x: V) -> bool {
                     Test::eq(&x.exp(), &Ratio::from(x).exp().get::<r::ratio>())
+                }
+
+                fn exp2(x: V) -> bool {
+                    Test::eq(&x.exp2(), &Ratio::from(x).exp2().get::<r::ratio>())
+                }
+
+                fn ln(x: V) -> bool {
+                    Test::eq(&x.ln(), &Ratio::from(x).ln().get::<r::ratio>())
+                }
+
+                fn log2(x: V) -> bool {
+                    Test::eq(&x.log2(), &Ratio::from(x).log2().get::<r::ratio>())
+                }
+
+                fn log10(x: V) -> bool {
+                    Test::eq(&x.log10(), &Ratio::from(x).log10().get::<r::ratio>())
+                }
+
+                fn exp_m1(x: V) -> bool {
+                    Test::eq(&x.exp_m1(), &Ratio::from(x).exp_m1().get::<r::ratio>())
+                }
+
+                fn ln_1p(x: V) -> bool {
+                    Test::eq(&x.ln_1p(), &Ratio::from(x).ln_1p().get::<r::ratio>())
                 }
             }
         }

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -98,6 +98,17 @@ where
         Ratio::new::<ratio>(self.value.ln())
     }
 
+    /// Returns the logarithm of the number with respect to an arbitrary base.
+    ///
+    /// The result might not be correctly rounded owing to implementation
+    /// details; self.log2() can produce more accurate results for base 2, and
+    /// self.log10() can produce more accurate results for base 10.
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn log(self, base: V) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.log(base))
+    }
+
     /// Returns the base 2 logarithm of the number.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
@@ -248,6 +259,10 @@ mod tests {
 
                 fn ln(x: V) -> bool {
                     Test::eq(&x.ln(), &Ratio::from(x).ln().get::<r::ratio>())
+                }
+
+                fn log(x: V, y: V) -> bool {
+                    Test::eq(&x.log(y), &Ratio::from(x).log(y).get::<r::ratio>())
                 }
 
                 fn log2(x: V) -> bool {

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -77,6 +77,22 @@ where
     }
 }
 
+/// Implementation of various stdlib exponentiation and logarithm functions
+#[cfg(feature = "std")]
+impl<U, V> Ratio<U, V>
+where
+    U: crate::si::Units<V> + ?Sized,
+    V: crate::num::Float + crate::Conversion<V>,
+    ratio: crate::Conversion<V, T = V::T>,
+{
+    /// Returns `e^(self)`, (the exponential function).
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline(always)]
+    pub fn exp(self) -> Ratio<U, V> {
+        Ratio::new::<ratio>(self.value.exp())
+    }
+}
+
 mod convert {
     use super::*;
 
@@ -184,6 +200,23 @@ mod tests {
 
                 fn atanh(x: V) -> bool {
                     Test::eq(&x.atanh(), &Ratio::from(x).atanh().get::<a::radian>())
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    mod exp_and_log {
+        storage_types! {
+            types: Float;
+
+            use crate::si::ratio as r;
+            use crate::si::quantities::*;
+            use crate::tests::Test;
+
+            quickcheck! {
+                fn exp(x: V) -> bool {
+                    Test::eq(&x.exp(), &Ratio::from(x).exp().get::<r::ratio>())
                 }
             }
         }

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -42,36 +42,42 @@ where
     ratio: crate::Conversion<V, T = V::T>,
 {
     /// Computes the value of the inverse cosine of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn acos(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.acos())
     }
 
     /// Computes the value of the inverse hyperbolic cosine of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn acosh(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.acosh())
     }
 
     /// Computes the value of the inverse sine of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn asin(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.asin())
     }
 
     /// Computes the value of the inverse hyperbolic sine of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn asinh(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.asinh())
     }
 
     /// Computes the value of the inverse tangent of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn atan(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.atan())
     }
 
     /// Computes the value of the inverse hyperbolic tangent of the ratio.
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     pub fn atanh(self) -> Angle<U, V> {
         Angle::new::<radian>(self.value.atanh())


### PR DESCRIPTION
Close #290.

Please have a look if this is up to standard. If so, I'd be happy to add `exp2`, `ln`, `log`,  `log2` and `log10` in a similar fashion.