### PR TITLE
adding new unit of measure for amount  of substance: "particle"

### DIFF
--- a/src/si/amount_of_substance.rs
+++ b/src/si/amount_of_substance.rs
@@ -41,5 +41,9 @@ quantity! {
         @attomole: prefix!(atto); "amol", "attomole", "attomoles";
         @zeptomole: prefix!(zepto); "zmol", "zeptomole", "zeptomoles";
         @yoctomole: prefix!(yocto); "ymol", "yoctomole", "yoctomoles";
+
+        /// One elementary entity may be an atom, a molecule, an ion, an electron, any other
+        /// particle or specified group of particles.
+        @particle: 1.0_E0 / 6.022_140_76_E23; "particle", "particle", "particles";
     }
 }

--- a/src/si/catalytic_activity.rs
+++ b/src/si/catalytic_activity.rs
@@ -77,6 +77,9 @@ quantity! {
             "zU", "zepto enzyme unit", "zepto enzyme units";
         @yocto_enzyme_unit: prefix!(yocto) * prefix!(micro) / 6.0_E1;
             "yU", "yocto enzyme unit", "yocto enzyme units";
+
+        @particle_per_second: 1.0_E0 / 6.022_140_76_E23; "particle/s", "particle per second",
+            "particles per second";
     }
 }
 
@@ -137,6 +140,8 @@ mod tests {
             test::<aos::attomole, t::minute, ca::pico_enzyme_unit>();
             test::<aos::zeptomole, t::minute, ca::femto_enzyme_unit>();
             test::<aos::yoctomole, t::minute, ca::atto_enzyme_unit>();
+
+            test::<aos::particle, t::second, ca::particle_per_second>();
 
             fn test<AOS: aos::Conversion<V>, T: t::Conversion<V>, CA: ca::Conversion<V>>() {
                 Test::assert_approx_eq(

--- a/src/si/catalytic_activity_concentration.rs
+++ b/src/si/catalytic_activity_concentration.rs
@@ -274,6 +274,9 @@ quantity! {
         @femto_enzyme_unit_per_milliliter:
             prefix!(femto) * prefix!(micro) / 6.0_E1 / prefix!(milli) / prefix!(milli);
             "fU/mL", "femto enzyme unit per milliliter", "femto enzyme units per milliliter";
+
+        @particle_per_second_cubic_meter: 1.0_E0 / 6.022_140_76_E23; "particle · s⁻¹ · m⁻³",
+            "particle per second cubic meter", "particles per second cubic meter";
     }
 }
 
@@ -408,6 +411,8 @@ mod test {
             test::<ca::nano_enzyme_unit, v::milliliter, c::nano_enzyme_unit_per_milliliter>();
             test::<ca::pico_enzyme_unit, v::milliliter, c::pico_enzyme_unit_per_milliliter>();
             test::<ca::femto_enzyme_unit, v::milliliter, c::femto_enzyme_unit_per_milliliter>();
+
+            test::<ca::particle_per_second, v::cubic_meter, c::particle_per_second_cubic_meter>();
 
             fn test<CA: ca::Conversion<V>, U: v::Conversion<V>, C: c::Conversion<V>>() {
                 Test::assert_approx_eq(&CatalyticActivityConcentration::new::<C>(V::one()),

--- a/src/si/molar_concentration.rs
+++ b/src/si/molar_concentration.rs
@@ -143,6 +143,18 @@ quantity! {
         @femtomole_per_milliliter:
             prefix!(femto) / prefix!(milli) / prefix!(milli);
             "fmol/mL", "femtomole per milliliter", "femtomoles per milliliter";
+
+        @particle_per_cubic_meter: 1.0_E0 / 6.022_140_76_E23; "particle/m³",
+            "particle per cubic meter", "particles per cubic meter";
+        @particle_per_cubic_decimeter:
+            1.0_E0 / 6.022_140_76_E23 / prefix!(deci) / prefix!(deci) / prefix!(deci);
+            "particle/dm³", "particle per cubic decimeter", "particles per cubic decimeter";
+        @particle_per_liter: 1.0_E0 / 6.022_140_76_E23 / prefix!(milli); "particle/L",
+            "particle per liter", "particles per liter";
+        @particle_per_deciliter: 1.0_E0 / 6.022_140_76_E23 / prefix!(deci) / prefix!(milli);
+            "particle/dL", "particle per deciliter", "particles per deciliter";
+        @particle_per_milliliter: 1.0_E0 / 6.022_140_76_E23 / prefix!(milli) / prefix!(milli);
+            "particle/mL", "particle per milliliter", "particles per milliliter";
     }
 }
 
@@ -216,6 +228,12 @@ mod test {
             test::<aos::nanomole, v::milliliter, c::nanomole_per_milliliter>();
             test::<aos::picomole, v::milliliter, c::picomole_per_milliliter>();
             test::<aos::femtomole, v::milliliter, c::femtomole_per_milliliter>();
+
+            test::<aos::particle, v::cubic_meter, c::particle_per_cubic_meter>();
+            test::<aos::particle, v::cubic_decimeter, c::particle_per_cubic_decimeter>();
+            test::<aos::particle, v::liter, c::particle_per_liter>();
+            test::<aos::particle, v::deciliter, c::particle_per_deciliter>();
+            test::<aos::particle, v::milliliter, c::particle_per_milliliter>();
 
             fn test<AOS: aos::Conversion<V>, U: v::Conversion<V>, C: c::Conversion<V>>() {
                 Test::assert_approx_eq(&MolarConcentration::new::<C>(V::one()),

--- a/src/si/molar_energy.rs
+++ b/src/si/molar_energy.rs
@@ -91,7 +91,7 @@ quantity! {
         @calorie_it_nutrition_per_mole: 4.186_8_E3; "Cal (IT)/mol", "Calorie (IT) per mole",
             "Calories (IT) per mole";
         @calorie_nutrition_per_mole: 4.184_E3; "Cal/mol", "Calorie per mole", "Calories per mole";
-        @electronvolt_per_mole: 1.602_177_E-19; "eV/mol", "electronvolt per mole",
+        @electronvolt_per_mole: 1.602_176_634_E-19; "eV/mol", "electronvolt per mole",
             "electronvolts per mole";
         @erg_per_mole: 1.0_E-7; "erg/mol", "erg per mole", "ergs per mole";
         @foot_poundal_per_mole: 4.214_011_E-2; "ft · pdl/mol", "foot poundal per mole",
@@ -108,6 +108,11 @@ quantity! {
         @therm_us_per_mole: 1.054_804_E8; "thm/mol", "therm per mole", "therms per mole";
         @ton_tnt_per_mole: 4.184_E9; "t of TNT/mol", "ton of TNT per mole", "tons of TNT per mole";
         @watt_second_per_mole: 1.0_E0; "W · s/mol", "watt second per mole", "watt seconds per mole";
+
+        @joule_per_particle: 6.022_140_76_E23; "J/particle", "joule per particle",
+            "joules per particle";
+        @electronvolt_per_particle: 1.602_176_634_E-19 * 6.022_140_76_E23; "eV/particle",
+            "electronvolt per particle", "electronvolts per particle";
     }
 }
 
@@ -139,81 +144,84 @@ mod tests {
 
         #[test]
         fn check_base_units() {
-            test::<m::kilogram, me::kilogram_square_meter_per_second_squared_mole>();
+            test::<m::kilogram, aos::mole, me::kilogram_square_meter_per_second_squared_mole>();
 
-            fn test<M: m::Conversion<V>, ME: me::Conversion<V>>() {
+            fn test<M: m::Conversion<V>, A: aos::Conversion<V>, ME: me::Conversion<V>>() {
                 Test::assert_approx_eq(&MolarEnergy::new::<ME>(V::one()),
                     &(Mass::new::<M>(V::one())
                         * Length::new::<l::meter>(V::one())
                         * Length::new::<l::meter>(V::one())
                         / (Time::new::<t::second>(V::one())
                             * Time::new::<t::second>(V::one())
-                            * AmountOfSubstance::new::<aos::mole>(V::one()))));
+                            * AmountOfSubstance::new::<A>(V::one()))));
             }
         }
 
         #[test]
         fn check_derived_units() {
-            test::<e::yottajoule, me::yottajoule_per_mole>();
-            test::<e::zettajoule, me::zettajoule_per_mole>();
-            test::<e::exajoule, me::exajoule_per_mole>();
-            test::<e::petajoule, me::petajoule_per_mole>();
-            test::<e::terajoule, me::terajoule_per_mole>();
-            test::<e::gigajoule, me::gigajoule_per_mole>();
-            test::<e::megajoule, me::megajoule_per_mole>();
-            test::<e::kilojoule, me::kilojoule_per_mole>();
-            test::<e::hectojoule, me::hectojoule_per_mole>();
-            test::<e::decajoule, me::decajoule_per_mole>();
-            test::<e::joule, me::joule_per_mole>();
-            test::<e::decijoule, me::decijoule_per_mole>();
-            test::<e::centijoule, me::centijoule_per_mole>();
-            test::<e::millijoule, me::millijoule_per_mole>();
-            test::<e::microjoule, me::microjoule_per_mole>();
-            test::<e::nanojoule, me::nanojoule_per_mole>();
-            test::<e::picojoule, me::picojoule_per_mole>();
-            test::<e::femtojoule, me::femtojoule_per_mole>();
-            test::<e::attojoule, me::attojoule_per_mole>();
-            test::<e::zeptojoule, me::zeptojoule_per_mole>();
-            test::<e::yoctojoule, me::yoctojoule_per_mole>();
+            test::<e::yottajoule, aos::mole, me::yottajoule_per_mole>();
+            test::<e::zettajoule, aos::mole, me::zettajoule_per_mole>();
+            test::<e::exajoule, aos::mole, me::exajoule_per_mole>();
+            test::<e::petajoule, aos::mole, me::petajoule_per_mole>();
+            test::<e::terajoule, aos::mole, me::terajoule_per_mole>();
+            test::<e::gigajoule, aos::mole, me::gigajoule_per_mole>();
+            test::<e::megajoule, aos::mole, me::megajoule_per_mole>();
+            test::<e::kilojoule, aos::mole, me::kilojoule_per_mole>();
+            test::<e::hectojoule, aos::mole, me::hectojoule_per_mole>();
+            test::<e::decajoule, aos::mole, me::decajoule_per_mole>();
+            test::<e::joule, aos::mole, me::joule_per_mole>();
+            test::<e::decijoule, aos::mole, me::decijoule_per_mole>();
+            test::<e::centijoule, aos::mole, me::centijoule_per_mole>();
+            test::<e::millijoule, aos::mole, me::millijoule_per_mole>();
+            test::<e::microjoule, aos::mole, me::microjoule_per_mole>();
+            test::<e::nanojoule, aos::mole, me::nanojoule_per_mole>();
+            test::<e::picojoule, aos::mole, me::picojoule_per_mole>();
+            test::<e::femtojoule, aos::mole, me::femtojoule_per_mole>();
+            test::<e::attojoule, aos::mole, me::attojoule_per_mole>();
+            test::<e::zeptojoule, aos::mole, me::zeptojoule_per_mole>();
+            test::<e::yoctojoule, aos::mole, me::yoctojoule_per_mole>();
 
-            test::<e::petawatt_hour, me::petawatt_hour_per_mole>();
-            test::<e::terawatt_hour, me::terawatt_hour_per_mole>();
-            test::<e::gigawatt_hour, me::gigawatt_hour_per_mole>();
-            test::<e::megawatt_hour, me::megawatt_hour_per_mole>();
-            test::<e::kilowatt_hour, me::kilowatt_hour_per_mole>();
-            test::<e::hectowatt_hour, me::hectowatt_hour_per_mole>();
-            test::<e::decawatt_hour, me::decawatt_hour_per_mole>();
-            test::<e::watt_hour, me::watt_hour_per_mole>();
-            test::<e::milliwatt_hour, me::milliwatt_hour_per_mole>();
-            test::<e::microwatt_hour, me::microwatt_hour_per_mole>();
+            test::<e::petawatt_hour, aos::mole, me::petawatt_hour_per_mole>();
+            test::<e::terawatt_hour, aos::mole, me::terawatt_hour_per_mole>();
+            test::<e::gigawatt_hour, aos::mole, me::gigawatt_hour_per_mole>();
+            test::<e::megawatt_hour, aos::mole, me::megawatt_hour_per_mole>();
+            test::<e::kilowatt_hour, aos::mole, me::kilowatt_hour_per_mole>();
+            test::<e::hectowatt_hour, aos::mole, me::hectowatt_hour_per_mole>();
+            test::<e::decawatt_hour, aos::mole, me::decawatt_hour_per_mole>();
+            test::<e::watt_hour, aos::mole, me::watt_hour_per_mole>();
+            test::<e::milliwatt_hour, aos::mole, me::milliwatt_hour_per_mole>();
+            test::<e::microwatt_hour, aos::mole, me::microwatt_hour_per_mole>();
 
-            test::<e::btu_it, me::btu_it_per_mole>();
-            test::<e::btu, me::btu_per_mole>();
-            test::<e::btu_39, me::btu_39_per_mole>();
-            test::<e::btu_59, me::btu_59_per_mole>();
-            test::<e::btu_60, me::btu_60_per_mole>();
-            test::<e::calorie_it, me::calorie_it_per_mole>();
-            test::<e::calorie, me::calorie_per_mole>();
-            test::<e::calorie_15, me::calorie_15_per_mole>();
-            test::<e::calorie_20, me::calorie_20_per_mole>();
-            test::<e::calorie_it_nutrition, me::calorie_it_nutrition_per_mole>();
-            test::<e::calorie_nutrition, me::calorie_nutrition_per_mole>();
-            test::<e::electronvolt, me::electronvolt_per_mole>();
-            test::<e::erg, me::erg_per_mole>();
-            test::<e::foot_poundal, me::foot_poundal_per_mole>();
-            test::<e::foot_pound, me::foot_pound_force_per_mole>();
-            test::<e::kilocalorie_it, me::kilocalorie_it_per_mole>();
-            test::<e::kilocalorie, me::kilocalorie_per_mole>();
-            test::<e::quad, me::quad_per_mole>();
-            test::<e::therm_ec, me::therm_ec_per_mole>();
-            test::<e::therm_us, me::therm_us_per_mole>();
-            test::<e::ton_tnt, me::ton_tnt_per_mole>();
-            test::<e::watt_second, me::watt_second_per_mole>();
+            test::<e::btu_it, aos::mole, me::btu_it_per_mole>();
+            test::<e::btu, aos::mole, me::btu_per_mole>();
+            test::<e::btu_39, aos::mole, me::btu_39_per_mole>();
+            test::<e::btu_59, aos::mole, me::btu_59_per_mole>();
+            test::<e::btu_60, aos::mole, me::btu_60_per_mole>();
+            test::<e::calorie_it, aos::mole, me::calorie_it_per_mole>();
+            test::<e::calorie, aos::mole, me::calorie_per_mole>();
+            test::<e::calorie_15, aos::mole, me::calorie_15_per_mole>();
+            test::<e::calorie_20, aos::mole, me::calorie_20_per_mole>();
+            test::<e::calorie_it_nutrition, aos::mole, me::calorie_it_nutrition_per_mole>();
+            test::<e::calorie_nutrition, aos::mole, me::calorie_nutrition_per_mole>();
+            test::<e::electronvolt, aos::mole, me::electronvolt_per_mole>();
+            test::<e::erg, aos::mole, me::erg_per_mole>();
+            test::<e::foot_poundal, aos::mole, me::foot_poundal_per_mole>();
+            test::<e::foot_pound, aos::mole, me::foot_pound_force_per_mole>();
+            test::<e::kilocalorie_it, aos::mole, me::kilocalorie_it_per_mole>();
+            test::<e::kilocalorie, aos::mole, me::kilocalorie_per_mole>();
+            test::<e::quad, aos::mole, me::quad_per_mole>();
+            test::<e::therm_ec, aos::mole, me::therm_ec_per_mole>();
+            test::<e::therm_us, aos::mole, me::therm_us_per_mole>();
+            test::<e::ton_tnt, aos::mole, me::ton_tnt_per_mole>();
+            test::<e::watt_second, aos::mole, me::watt_second_per_mole>();
 
-            fn test<E: e::Conversion<V>, ME: me::Conversion<V>>() {
+            test::<e::joule, aos::particle, me::joule_per_particle>();
+            test::<e::electronvolt, aos::particle, me::electronvolt_per_particle>();
+
+            fn test<E: e::Conversion<V>, AOS: aos::Conversion<V>, ME: me::Conversion<V>>() {
                 Test::assert_approx_eq(&MolarEnergy::new::<ME>(V::one()),
                     &(Energy::new::<E>(V::one())
-                        / AmountOfSubstance::new::<aos::mole>(V::one())));
+                        / AmountOfSubstance::new::<AOS>(V::one())));
             }
         }
     }

--- a/src/si/molar_heat_capacity.rs
+++ b/src/si/molar_heat_capacity.rs
@@ -88,6 +88,12 @@ quantity! {
             "kilocalorie (IT) per kelvin mole", "kilocalories (IT) per kelvin mole";
         @kilocalorie_per_kelvin_mole: 4.184_E3; "kcal/(K · mol)", "kilocalorie per kelvin mole",
             "kilocalories per kelvin mole";
+
+        @joule_per_kelvin_particle: 6.022_140_76_E23; "J/(K · particle)",
+            "joule per kelvin particle", "joules per kelvin particle";
+        @electronvolt_per_kelvin_particle: 6.022_140_76_E23 * 1.602_176_634_E-19;
+            "eV/(K · particle)", "electronvolt per kelvin particle",
+            "electronvolts per kelvin particle";
     }
 }
 
@@ -95,7 +101,7 @@ quantity! {
 mod tests {
     storage_types! {
         use crate::num::One;
-        use crate::si::amount_of_substance as a;
+        use crate::si::amount_of_substance as aos;
         use crate::si::energy as e;
         use crate::si::molar_heat_capacity as m;
         use crate::si::quantities::*;
@@ -106,52 +112,56 @@ mod tests {
         fn check_dimension() {
             let _: MolarHeatCapacity<V> = Energy::new::<e::joule>(V::one())
                 / (TemperatureInterval::new::<t::kelvin>(V::one())
-                    * AmountOfSubstance::new::<a::mole>(V::one()));
+                    * AmountOfSubstance::new::<aos::mole>(V::one()));
         }
 
         #[test]
         fn check_units() {
-            test::<e::yottajoule, t::kelvin, a::mole, m::yottajoule_per_kelvin_mole>();
-            test::<e::zettajoule, t::kelvin, a::mole, m::zettajoule_per_kelvin_mole>();
-            test::<e::exajoule, t::kelvin, a::mole, m::exajoule_per_kelvin_mole>();
-            test::<e::petajoule, t::kelvin, a::mole, m::petajoule_per_kelvin_mole>();
-            test::<e::terajoule, t::kelvin, a::mole, m::terajoule_per_kelvin_mole>();
-            test::<e::gigajoule, t::kelvin, a::mole, m::gigajoule_per_kelvin_mole>();
-            test::<e::megajoule, t::kelvin, a::mole, m::megajoule_per_kelvin_mole>();
-            test::<e::kilojoule, t::kelvin, a::mole, m::kilojoule_per_kelvin_mole>();
-            test::<e::hectojoule, t::kelvin, a::mole, m::hectojoule_per_kelvin_mole>();
-            test::<e::decajoule, t::kelvin, a::mole, m::decajoule_per_kelvin_mole>();
-            test::<e::joule, t::kelvin, a::mole, m::joule_per_kelvin_mole>();
-            test::<e::decijoule, t::kelvin, a::mole, m::decijoule_per_kelvin_mole>();
-            test::<e::centijoule, t::kelvin, a::mole, m::centijoule_per_kelvin_mole>();
-            test::<e::millijoule, t::kelvin, a::mole, m::millijoule_per_kelvin_mole>();
-            test::<e::microjoule, t::kelvin, a::mole, m::microjoule_per_kelvin_mole>();
-            test::<e::nanojoule, t::kelvin, a::mole, m::nanojoule_per_kelvin_mole>();
-            test::<e::picojoule, t::kelvin, a::mole, m::picojoule_per_kelvin_mole>();
-            test::<e::femtojoule, t::kelvin, a::mole, m::femtojoule_per_kelvin_mole>();
-            test::<e::attojoule, t::kelvin, a::mole, m::attojoule_per_kelvin_mole>();
-            test::<e::zeptojoule, t::kelvin, a::mole, m::zeptojoule_per_kelvin_mole>();
-            test::<e::yoctojoule, t::kelvin, a::mole, m::yoctojoule_per_kelvin_mole>();
+            test::<e::yottajoule, t::kelvin, aos::mole, m::yottajoule_per_kelvin_mole>();
+            test::<e::zettajoule, t::kelvin, aos::mole, m::zettajoule_per_kelvin_mole>();
+            test::<e::exajoule, t::kelvin, aos::mole, m::exajoule_per_kelvin_mole>();
+            test::<e::petajoule, t::kelvin, aos::mole, m::petajoule_per_kelvin_mole>();
+            test::<e::terajoule, t::kelvin, aos::mole, m::terajoule_per_kelvin_mole>();
+            test::<e::gigajoule, t::kelvin, aos::mole, m::gigajoule_per_kelvin_mole>();
+            test::<e::megajoule, t::kelvin, aos::mole, m::megajoule_per_kelvin_mole>();
+            test::<e::kilojoule, t::kelvin, aos::mole, m::kilojoule_per_kelvin_mole>();
+            test::<e::hectojoule, t::kelvin, aos::mole, m::hectojoule_per_kelvin_mole>();
+            test::<e::decajoule, t::kelvin, aos::mole, m::decajoule_per_kelvin_mole>();
+            test::<e::joule, t::kelvin, aos::mole, m::joule_per_kelvin_mole>();
+            test::<e::decijoule, t::kelvin, aos::mole, m::decijoule_per_kelvin_mole>();
+            test::<e::centijoule, t::kelvin, aos::mole, m::centijoule_per_kelvin_mole>();
+            test::<e::millijoule, t::kelvin, aos::mole, m::millijoule_per_kelvin_mole>();
+            test::<e::microjoule, t::kelvin, aos::mole, m::microjoule_per_kelvin_mole>();
+            test::<e::nanojoule, t::kelvin, aos::mole, m::nanojoule_per_kelvin_mole>();
+            test::<e::picojoule, t::kelvin, aos::mole, m::picojoule_per_kelvin_mole>();
+            test::<e::femtojoule, t::kelvin, aos::mole, m::femtojoule_per_kelvin_mole>();
+            test::<e::attojoule, t::kelvin, aos::mole, m::attojoule_per_kelvin_mole>();
+            test::<e::zeptojoule, t::kelvin, aos::mole, m::zeptojoule_per_kelvin_mole>();
+            test::<e::yoctojoule, t::kelvin, aos::mole, m::yoctojoule_per_kelvin_mole>();
 
-            test::<e::btu_it, t::kelvin, a::mole, m::btu_it_per_kelvin_mole>();
-            test::<e::btu, t::kelvin, a::mole, m::btu_per_kelvin_mole>();
-            test::<e::btu_39, t::kelvin, a::mole, m::btu_39_per_kelvin_mole>();
-            test::<e::btu_59, t::kelvin, a::mole, m::btu_59_per_kelvin_mole>();
-            test::<e::btu_60, t::kelvin, a::mole, m::btu_60_per_kelvin_mole>();
-            test::<e::calorie_it, t::kelvin, a::mole, m::calorie_it_per_kelvin_mole>();
-            test::<e::calorie, t::kelvin, a::mole, m::calorie_per_kelvin_mole>();
-            test::<e::calorie_15, t::kelvin, a::mole, m::calorie_15_per_kelvin_mole>();
-            test::<e::calorie_20, t::kelvin, a::mole, m::calorie_20_per_kelvin_mole>();
-            test::<e::calorie_it_nutrition, t::kelvin, a::mole, m::calorie_it_nutrition_per_kelvin_mole>();
-            test::<e::calorie_nutrition, t::kelvin, a::mole, m::calorie_nutrition_per_kelvin_mole>();
-            test::<e::kilocalorie_it, t::kelvin, a::mole, m::kilocalorie_it_per_kelvin_mole>();
-            test::<e::kilocalorie, t::kelvin, a::mole, m::kilocalorie_per_kelvin_mole>();
+            test::<e::btu_it, t::kelvin, aos::mole, m::btu_it_per_kelvin_mole>();
+            test::<e::btu, t::kelvin, aos::mole, m::btu_per_kelvin_mole>();
+            test::<e::btu_39, t::kelvin, aos::mole, m::btu_39_per_kelvin_mole>();
+            test::<e::btu_59, t::kelvin, aos::mole, m::btu_59_per_kelvin_mole>();
+            test::<e::btu_60, t::kelvin, aos::mole, m::btu_60_per_kelvin_mole>();
+            test::<e::calorie_it, t::kelvin, aos::mole, m::calorie_it_per_kelvin_mole>();
+            test::<e::calorie, t::kelvin, aos::mole, m::calorie_per_kelvin_mole>();
+            test::<e::calorie_15, t::kelvin, aos::mole, m::calorie_15_per_kelvin_mole>();
+            test::<e::calorie_20, t::kelvin, aos::mole, m::calorie_20_per_kelvin_mole>();
+            test::<e::calorie_it_nutrition, t::kelvin, aos::mole, m::calorie_it_nutrition_per_kelvin_mole>();
+            test::<e::calorie_nutrition, t::kelvin, aos::mole, m::calorie_nutrition_per_kelvin_mole>();
+            test::<e::kilocalorie_it, t::kelvin, aos::mole, m::kilocalorie_it_per_kelvin_mole>();
+            test::<e::kilocalorie, t::kelvin, aos::mole, m::kilocalorie_per_kelvin_mole>();
 
-            fn test<E: e::Conversion<V>, T: t::Conversion<V>, A: a::Conversion<V>, M: m::Conversion<V>>() {
+            test::<e::joule, t::kelvin, aos::particle, m::joule_per_kelvin_particle>();
+            test::<e::electronvolt, t::kelvin, aos::particle,
+                m::electronvolt_per_kelvin_particle>();
+
+            fn test<E: e::Conversion<V>, T: t::Conversion<V>, AOS: aos::Conversion<V>, M: m::Conversion<V>>() {
                 Test::assert_approx_eq(&MolarHeatCapacity::new::<M>(V::one()),
                     &(Energy::new::<E>(V::one())
                         / (TemperatureInterval::new::<T>(V::one())
-                            * AmountOfSubstance::new::<A>(V::one()))));
+                            * AmountOfSubstance::new::<AOS>(V::one()))));
             }
         }
     }


### PR DESCRIPTION
This PR adds new units of measure for amount of substance: "particle" as proposed in  #317.
New definitions and tests added for amount_of_substance, molar_energy, molar_heat_capacity, molar_concentration, catalytic_activity, and catalytic_activity_concentration.
Tests for molar_energy were amended to be generic over the amount of substance units.
