### PR TITLE
Add atomic units of energy, mass, length, electric charge and current.

### DIFF
--- a/src/si/electric_charge.rs
+++ b/src/si/electric_charge.rs
@@ -47,6 +47,10 @@ quantity! {
         @milliampere_hour: 3.6_E0; "mA · h", "milliampere hour", "milliampere hours";
         @microampere_hour: 3.6_E-3; "µA · h", "microampere hour", "microampere hours";
 
+        /// Electric charge carried by a single proton.
+        @elementary_charge: 1.602_176_634_E-19; "e", "elementary charge", "elementary charges";
+        @atomic_unit_of_charge: 1.602_176_634_E-19; "a.u. of charge", "atomic unit of charge",
+            "atomic units of charge";
         @abcoulomb: 1.0_E1; "abC", "abcoulomb", "abcoulombs";
         @faraday: 9.648_531_E4; "F", "faraday", "faradays";
         @franklin: 3.335_641_E-10; "Fr", "franklin", "franklins";
@@ -94,6 +98,8 @@ mod tests {
             test::<i::zeptoampere, t::second, q::zeptocoulomb>();
             test::<i::yoctoampere, t::second, q::yoctocoulomb>();
 
+            test::<i::elementary_charge_per_second, t::second, q::elementary_charge>();
+            test::<i::atomic_unit_of_charge_per_second, t::second, q::atomic_unit_of_charge>();
             test::<i::ampere, t::hour, q::ampere_hour>();
             test::<i::abampere, t::second, q::abcoulomb>();
             test::<i::statampere, t::second, q::statcoulomb>();

--- a/src/si/electric_current.rs
+++ b/src/si/electric_current.rs
@@ -39,6 +39,11 @@ quantity! {
         @zeptoampere: prefix!(zepto); "zA", "zeptoampere", "zeptoamperes";
         @yoctoampere: prefix!(yocto); "yA", "yoctoampere", "yoctoamperes";
 
+        /// Atomic unit of charge (electric charge carried by a single proton) per second.
+        @elementary_charge_per_second: 1.602_176_634_E-19; "e/s", "elementary charge per second",
+            "elementary charges per second";
+        @atomic_unit_of_charge_per_second: 1.602_176_634_E-19; "a.u. of charge/s",
+            "atomic unit of charge per second", "atomic units of charge per second";
         @abampere: 1.0_E1; "abA", "abampere", "abamperes";
         @gilbert: 7.957_747_E-1; "Gi", "gilbert", "gilberts";
         @statampere: 3.335_641_E-10; "statA", "statampere", "statamperes";

--- a/src/si/energy.rs
+++ b/src/si/energy.rs
@@ -56,6 +56,9 @@ quantity! {
         @decaelectronvolt: 1.602_176_634_E-18; "daeV", "decaelectronvolt", "decaelectronvolts";
         @electronvolt: 1.602_176_634_E-19; "eV", "electronvolt", "electronvolts";
 
+        /// Atomic unit of energy (Hartree energy).
+        @hartree: 4.359_744_722_207_1_E-18; "Eₕ", "hartree", "hartrees";
+
         @btu_it: 1.055_056_E3; "Btu (IT)", "British thermal unit (IT)",
             "British thermal units (IT)";
         @btu: 1.054_350_E3; "Btu", "British thermal unit", "British thermal units";

--- a/src/si/length.rs
+++ b/src/si/length.rs
@@ -39,6 +39,10 @@ quantity! {
         @yoctometer: prefix!(yocto); "ym", "yoctometer", "yoctometers";
 
         @angstrom: 1.0_E-10; "Å", "ångström", "ångströms";
+        @bohr_radius: 5.291_772_109_03_E-11; "a₀", "bohr radius", "bohr radiuses";
+        /// Atomic unit of length (Bohr radius).
+        @atomic_unit_of_length: 5.291_772_109_03_E-11; "a.u. of length", "atomic unit of length",
+            "atomic units of length";
         @astronomical_unit: 1.495_979_E11; "ua", "astronomical unit", "astronomical units";
         @chain: 2.011_684_E1; "ch", "chain", "chains";
         @fathom: 1.828_804_E0; "fathom", "fathom", "fathoms";

--- a/src/si/mass.rs
+++ b/src/si/mass.rs
@@ -40,6 +40,8 @@ quantity! {
         @yoctogram: prefix!(yocto) / prefix!(kilo); "yg", "yoctogram", "yoctograms";
 
         @carat: 2.0_E-4; "ct", "carat", "carats";
+        /// Unified atomic mass unit.
+        @dalton: 1.660_539_066_60_E-27; "Da", "dalton", "daltons";
         @grain: 6.479_891_E-5; "gr", "grain", "grains";
         @hundredweight_long: 5.080_235_E1; "cwt long", "hundredweight (long)", "hundredweight (long)";
         @hundredweight_short: 4.535_924_E1; "cwt short", "hundredweight (short)", "hundredweight (short)";


### PR DESCRIPTION
Adding 

- Dalton (unified atomic mass unit = 1/12 * (mass of C12))
- Hartree (atomic unit of energy, ~27.2 eV)
- atomic unit of length (Bohr radius, 5.291 772 109 03 x 10-11 m )
- atomic unit of charge (absolute charge of electron, 1.602_176_634 x 10^-19 C)
