### PR TITLE
Add specific number rates: volumetric, areal, and linear.

### DIFF
--- a/src/si/areal_number_rate.rs
+++ b/src/si/areal_number_rate.rs
@@ -1,0 +1,82 @@
+//! Areal number rate (base unit 1 per square meter second, m⁻² · s⁻¹).
+
+quantity! {
+    /// Areal number rate (base unit 1 per square meter second, m⁻² · s⁻¹).
+    quantity: ArealNumberRate; "areal number rate";
+    /// Dimension of areal number rate, L⁻²T⁻¹ (base unit 1 per square meter second, m⁻² · s⁻¹).
+    dimension: ISQ<
+        N2,     // length
+        Z0,     // mass
+        N1,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    units {
+        @per_square_meter_second: prefix!(none); "m⁻² · s⁻¹", "per square meter second",
+            "per square meter second";
+        @per_square_centimeter_second: prefix!(none) / prefix!(centi) / prefix!(centi);
+            "cm⁻² · s⁻¹", "per square centimeter second", "per square centimeter second";
+
+        @per_acre_second: prefix!(none) / 4.046_873_E3; "ac⁻¹ · s⁻¹", "per acre second",
+            "per acre second";
+        @per_are_second: prefix!(none) / 1.0_E2; "a⁻¹ · s⁻¹", "per are second", "per are second";
+        @per_barn_second: prefix!(none) / 1.0_E-28; "b⁻¹ · s⁻¹", "per barn second",
+            "per barn second";
+        @per_circular_mil_second: prefix!(none) / 5.067_075_E-10; "cmil⁻¹ · s⁻¹",
+            "per circular mil second", "per circular mil second";
+        @per_hectare_second: prefix!(none) / 1.0_E4; "ha⁻¹ · s⁻¹", "per hectare second",
+            "per hectare second";
+        @per_square_foot_second: prefix!(none) / 9.290_304_E-2; "ft⁻² · s⁻¹",
+            "per square foot second", "per square foot second";
+        @per_square_inch_second: prefix!(none) / 6.451_6_E-4; "in⁻² · s⁻¹",
+            "per square inch second", "per square inch second";
+        @per_square_mile_second: prefix!(none) / 2.589_988_E6; "mi⁻² · s⁻¹",
+            "per square mile second", "per square mile second";
+        @per_square_yard_second: prefix!(none) / 8.361_274_E-1; "yd⁻² · s⁻¹",
+            "per square yard second", "per square yard second";
+    }
+}
+
+#[cfg(test)]
+mod test {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::areal_number_rate as anr;
+        use crate::si::quantities::*;
+        use crate::si::time as t;
+        use crate::si::area as a;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: ArealNumberRate<V> = (V::one()
+                / Time::new::<t::second>(V::one())
+                / Area::new::<a::square_meter>(V::one())).into();
+        }
+
+        #[test]
+        fn check_units() {
+            test::<anr::per_square_meter_second, a::square_meter, t::second>();
+            test::<anr::per_square_centimeter_second, a::square_centimeter, t::second>();
+
+            test::<anr::per_acre_second, a::acre, t::second>();
+            test::<anr::per_are_second, a::are, t::second>();
+            test::<anr::per_barn_second, a::barn, t::second>();
+            test::<anr::per_circular_mil_second, a::circular_mil, t::second>();
+            test::<anr::per_hectare_second, a::hectare, t::second>();
+            test::<anr::per_square_foot_second, a::square_foot, t::second>();
+            test::<anr::per_square_inch_second, a::square_inch, t::second>();
+            test::<anr::per_square_mile_second, a::square_mile, t::second>();
+            test::<anr::per_square_yard_second, a::square_yard, t::second>();
+
+            fn test<ANR: anr::Conversion<V>, A: a::Conversion<V>, T: t::Conversion<V>>() {
+                Test::assert_approx_eq(&ArealNumberRate::new::<ANR>(V::one()),
+                    &(V::one()
+                        / Time::new::<T>(V::one())
+                        / Area::new::<A>(V::one())).into());
+            }
+        }
+    }
+}

--- a/src/si/linear_number_rate.rs
+++ b/src/si/linear_number_rate.rs
@@ -1,0 +1,79 @@
+//! Linear number rate (base unit 1 per meter second, m⁻¹ · s⁻¹).
+
+quantity! {
+    /// Linear number rate (base unit 1 per meter second, m⁻¹ · s⁻¹).
+    quantity: LinearNumberRate; "linear number rate";
+    /// Dimension of linear number rate, L⁻¹T⁻¹ (base unit 1 per meter second, m⁻¹ · s⁻¹).
+    dimension: ISQ<
+        N1,     // length
+        Z0,     // mass
+        N1,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    units {
+        @per_kilometer_second: prefix!(none) / prefix!(kilo); "km⁻¹ · s⁻¹", "per kilometer second",
+            "per kilometer second";
+        @per_meter_second: prefix!(none); "m⁻¹ · s⁻¹", "per meter second", "per meter second";
+        @per_centimeter_second: prefix!(none) / prefix!(centi); "cm⁻¹ · s⁻¹",
+            "per centimeter second", "per centimeter second";
+        @per_millimeter_second: prefix!(none) / prefix!(milli); "mm⁻¹ · s⁻¹",
+            "per millimeter second", "per millimeter second";
+
+        @per_foot_second: prefix!(none) / 3.048_E-1; "ft⁻¹ · s⁻¹", "per foot second",
+            "per foot second";
+        @per_foot_survey_second: prefix!(none) / 3.048_006_E-1; "ft⁻¹ (U.S. survey) · s⁻¹",
+            "per foot (U.S. survey) second", "per foot (U.S. survey) second";
+        @per_inch_second: prefix!(none) / 2.54_E-2; "in⁻¹ · s⁻¹", "per inch second",
+            "per inch second";
+        @per_mile_second: prefix!(none) / 1.609_344_E3; "mi⁻¹ · s⁻¹", "per mile second",
+            "per mile second";
+        @per_mile_survey_second: prefix!(none) / 1.609_347_E3; "mi⁻¹ (U.S. survey) · s⁻¹",
+            "per mile (U.S. survey) second", "per mile (U.S. survey) second";
+        @per_yard_second: prefix!(none) / 9.144_E-1; "yd⁻¹ · s⁻¹", "per yard second",
+            "per yard second";
+    }
+}
+
+#[cfg(test)]
+mod test {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::linear_number_rate as lnr;
+        use crate::si::quantities::*;
+        use crate::si::time as t;
+        use crate::si::length as l;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: LinearNumberRate<V> = (V::one()
+                / Time::new::<t::second>(V::one())
+                / Length::new::<l::meter>(V::one())).into();
+        }
+
+        #[test]
+        fn check_units() {
+            test::<lnr::per_kilometer_second, l::kilometer, t::second>();
+            test::<lnr::per_meter_second, l::meter, t::second>();
+            test::<lnr::per_centimeter_second, l::centimeter, t::second>();
+            test::<lnr::per_millimeter_second, l::millimeter, t::second>();
+
+            test::<lnr::per_foot_second, l::foot, t::second>();
+            test::<lnr::per_foot_survey_second, l::foot_survey, t::second>();
+            test::<lnr::per_inch_second, l::inch, t::second>();
+            test::<lnr::per_mile_second, l::mile, t::second>();
+            test::<lnr::per_mile_survey_second, l::mile_survey, t::second>();
+            test::<lnr::per_yard_second, l::yard, t::second>();
+
+            fn test<LNR: lnr::Conversion<V>, L: l::Conversion<V>, T: t::Conversion<V>>() {
+                Test::assert_approx_eq(&LinearNumberRate::new::<LNR>(V::one()),
+                    &(V::one()
+                        / Time::new::<T>(V::one())
+                        / Length::new::<L>(V::one())).into());
+            }
+        }
+    }
+}

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -55,6 +55,7 @@ system! {
         area::Area,
         areal_mass_density::ArealMassDensity,
         areal_number_density::ArealNumberDensity,
+        areal_number_rate::ArealNumberRate,
         available_energy::AvailableEnergy,
         capacitance::Capacitance,
         catalytic_activity::CatalyticActivity,
@@ -88,6 +89,7 @@ system! {
         length::Length,
         linear_mass_density::LinearMassDensity,
         linear_number_density::LinearNumberDensity,
+        linear_number_rate::LinearNumberRate,
         linear_power_density::LinearPowerDensity,
         luminance::Luminance,
         luminous_intensity::LuminousIntensity,
@@ -127,6 +129,7 @@ system! {
         volume::Volume,
         volume_rate::VolumeRate,
         volumetric_number_density::VolumetricNumberDensity,
+        volumetric_number_rate::VolumetricNumberRate,
         volumetric_power_density::VolumetricPowerDensity,
     }
 }

--- a/src/si/volumetric_number_rate.rs
+++ b/src/si/volumetric_number_rate.rs
@@ -1,0 +1,91 @@
+//! Volumetric number rate (base unit 1 per cubic meter second, m⁻³ · s⁻¹).
+
+quantity! {
+    /// Volumetric number rate (base unit 1 per cubic meter second, m⁻³ · s⁻¹).
+    quantity: VolumetricNumberRate; "volumetric number rate";
+    /// Dimension of volumetric number rate, L⁻³T⁻¹ (base unit 1 per cubic meter second, m⁻³ · s⁻¹).
+    dimension: ISQ<
+        N3,     // length
+        Z0,     // mass
+        N1,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    units {
+        @per_cubic_meter_second: prefix!(none); "m⁻³ · s⁻¹",
+            "per cubic meter second", "per cubic meter second";
+        @per_cubic_centimeter_second:
+            prefix!(none) / prefix!(centi) / prefix!(centi) / prefix!(centi); "cm⁻³ · s⁻¹",
+            "per cubic centimeter second", "per cubic centimeter second";
+        @per_cubic_millimeter_second:
+            prefix!(none) / prefix!(milli) / prefix!(milli) / prefix!(milli); "mm⁻³ · s⁻¹",
+            "per cubic millimeter second", "per cubic millimeter second";
+
+        @per_cubic_foot_second: prefix!(none) / 2.831_685_E-2; "ft⁻³ · s⁻¹",
+            "per cubic foot second", "per cubic foot second";
+        @per_cubic_inch_second: prefix!(none) / 1.638_706_E-5; "in⁻³ · s⁻¹",
+            "per cubic inch second", "per cubic inch second";
+        @per_cubic_mile_second: prefix!(none) / 4.168_182_E9; "mi⁻³ · s⁻¹",
+            "per cubic mile second", "per cubic mile second";
+        @per_cubic_yard_second: prefix!(none) / 7.645_549_E-1; "yd⁻³ · s⁻¹",
+            "per cubic yard second", "per cubic yard second";
+        @per_fluid_ounce_second: prefix!(none) / 2.957_353_E-5; "fl oz⁻¹ · s⁻¹",
+            "per fluid ounce second", "per fluid ounce second";
+        @per_fluid_ounce_imperial_second: prefix!(none) / 2.841_306_E-5; "fl oz⁻¹ (UK) · s⁻¹",
+            "per Imperial fluid ounce second", "per Imperial fluid ounce second";
+        @per_gallon_imperial_second: prefix!(none) / 4.546_09_E-3; "gal⁻¹ (UK) · s⁻¹",
+            "per Imperial gallon second", "per Imperial gallon second";
+        @per_gallon_second: prefix!(none) / 3.785_412_E-3; "gal⁻¹ · s⁻¹", "per gallon second",
+            "per gallon second";
+        @per_liter_second: prefix!(none) / prefix!(milli); "L⁻¹ · s⁻¹", "per liter second",
+            "per liter second";
+        @per_milliliter_second: prefix!(none) / prefix!(milli) / prefix!(milli); "mL⁻¹ · s⁻¹",
+            "per milliliter second", "per milliliter second";
+    }
+}
+
+#[cfg(test)]
+mod test {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::volumetric_number_rate as vnr;
+        use crate::si::quantities::*;
+        use crate::si::time as t;
+        use crate::si::volume as vol;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: VolumetricNumberRate<V> = (V::one()
+                / Time::new::<t::second>(V::one())
+                / Volume::new::<vol::cubic_meter>(V::one())).into();
+        }
+
+        #[test]
+        fn check_units() {
+            test::<vnr::per_cubic_meter_second, vol::cubic_meter, t::second>();
+            test::<vnr::per_cubic_centimeter_second, vol::cubic_centimeter, t::second>();
+            test::<vnr::per_cubic_millimeter_second, vol::cubic_millimeter, t::second>();
+
+            test::<vnr::per_cubic_foot_second, vol::cubic_foot, t::second>();
+            test::<vnr::per_cubic_inch_second, vol::cubic_inch, t::second>();
+            test::<vnr::per_cubic_mile_second, vol::cubic_mile, t::second>();
+            test::<vnr::per_cubic_yard_second, vol::cubic_yard, t::second>();
+            test::<vnr::per_fluid_ounce_second, vol::fluid_ounce, t::second>();
+            test::<vnr::per_fluid_ounce_imperial_second, vol::fluid_ounce_imperial, t::second>();
+            test::<vnr::per_gallon_imperial_second, vol::gallon_imperial, t::second>();
+            test::<vnr::per_gallon_second, vol::gallon, t::second>();
+            test::<vnr::per_liter_second, vol::liter, t::second>();
+            test::<vnr::per_milliliter_second, vol::milliliter, t::second>();
+
+            fn test<VNR: vnr::Conversion<V>, VOL: vol::Conversion<V>, T: t::Conversion<V>>() {
+                Test::assert_approx_eq(&VolumetricNumberRate::new::<VNR>(V::one()),
+                    &(V::one()
+                        / Time::new::<T>(V::one())
+                        / Volume::new::<VOL>(V::one())).into());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add specific number rates

- Volumetric number rate [1 / (Volume x Time)]
- Areal number rate [1 / (Area x Time)]
- Linear number rate [1/ (Length x Time)]

Kind is ConstituentConcentrationKind

Typical applications:

-  molecule collision rate
- carrier recombination rate in semiconductor (volumetric for bulk recombination, areal for surface recombination and linear for recombination in linear defect or quantum wire)
-  nucleation rate (volumetric for homogeneous nucleation, areal for heterogeneous nucleation on surface)
