### PR TITLE
Add areal and linear specific power density

### DIFF
--- a/src/si/heat_flux_density.rs
+++ b/src/si/heat_flux_density.rs
@@ -56,6 +56,11 @@ quantity! {
             "zeptowatt per square meter", "zeptowatts per square meter";
         @yoctowatt_per_square_meter: prefix!(yocto); "yW/m²",
             "yoctowatt per square meter", "yoctowatts per square meter";
+
+        @watt_per_square_centimeter: prefix!(none) / prefix!(centi) / prefix!(centi); "W/cm²",
+            "watt per square centimeter", "watts per square centimeter";
+        @watt_per_square_millimeter: prefix!(none) / prefix!(milli) / prefix!(milli); "W/mm²",
+            "watt per square millimeter", "watts per square millimeter";
     }
 }
 
@@ -63,6 +68,7 @@ quantity! {
 mod test {
     storage_types! {
         use crate::num::One;
+        use crate::si::area as a;
         use crate::si::heat_flux_density as d;
         use crate::si::length as l;
         use crate::si::power as p;
@@ -107,6 +113,18 @@ mod test {
                     &(Power::new::<P>(V::one())
                       / (Length::new::<l::meter>(V::one())
                          * Length::new::<l::meter>(V::one()))));
+            }
+        }
+
+        #[test]
+        fn check_units_power_area() {
+            test::<p::watt, a::square_meter, d::watt_per_square_meter>();
+            test::<p::watt, a::square_centimeter, d::watt_per_square_centimeter>();
+            test::<p::watt, a::square_millimeter, d::watt_per_square_millimeter>();
+
+            fn test<P: p::Conversion<V>, A: a::Conversion<V>, D: d::Conversion<V>>() {
+                Test::assert_approx_eq(&HeatFluxDensity::new::<D>(V::one()),
+                    &(Power::new::<P>(V::one()) / Area::new::<A>(V::one())));
             }
         }
     }

--- a/src/si/linear_power_density.rs
+++ b/src/si/linear_power_density.rs
@@ -1,0 +1,52 @@
+//! Linear power density (base unit watt per meter, m · kg · s⁻³).
+
+quantity! {
+    /// Linear power density (base unit watt per meter, m · kg · s⁻³).
+    quantity: LinearPowerDensity; "linear power density";
+    /// Dimension of linear power density, LMT⁻³ (base unit watt per meter, m · kg · s⁻³).
+    dimension: ISQ<
+        P1,     // length
+        P1,     // mass
+        N3,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    units {
+        @watt_per_meter: prefix!(none); "W/m", "watt per meter", "watts per meter";
+        @watt_per_centimeter: prefix!(none) / prefix!(centi); "W/cm", "watt per centimeter",
+            "watts per centimeter";
+        @watt_per_millimeter: prefix!(none) / prefix!(milli); "W/mm", "watt per millimeter",
+            "watts per millimeter";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::power as p;
+        use crate::si::quantities::*;
+        use crate::si::linear_power_density as lpd;
+        use crate::si::length as l;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: LinearPowerDensity<V> =  Power::new::<p::watt>(V::one())
+                / Length::new::<l::meter>(V::one());
+        }
+
+        #[test]
+        fn check_units() {
+            test::<p::watt, l::meter, lpd::watt_per_meter>();
+            test::<p::watt, l::centimeter, lpd::watt_per_centimeter>();
+            test::<p::watt, l::millimeter, lpd::watt_per_millimeter>();
+
+            fn test<P: p::Conversion<V>, L: l::Conversion<V>, LPD: lpd::Conversion<V>>() {
+                Test::assert_approx_eq(&LinearPowerDensity::new::<LPD>(V::one()),
+                    &(Power::new::<P>(V::one()) / Length::new::<L>(V::one())));
+            }
+        }
+    }
+}

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -85,6 +85,7 @@ system! {
         jerk::Jerk,
         length::Length,
         linear_mass_density::LinearMassDensity,
+        linear_power_density::LinearPowerDensity,
         luminance::Luminance,
         luminous_intensity::LuminousIntensity,
         magnetic_field_strength::MagneticFieldStrength,
@@ -118,6 +119,7 @@ system! {
         velocity::Velocity,
         volume::Volume,
         volume_rate::VolumeRate,
+        volumetric_power_density::VolumetricPowerDensity,
     }
 }
 

--- a/src/si/volumetric_power_density.rs
+++ b/src/si/volumetric_power_density.rs
@@ -1,0 +1,56 @@
+//! Volumetric power density (base unit watt per cubic meter, m⁻¹ · kg · s⁻³).
+
+quantity! {
+    /// Volumetric power density (base unit watt per cubic meter, m⁻¹ · kg · s⁻³).
+    quantity: VolumetricPowerDensity; "volumetric power density";
+    /// Dimension of volumetric power density, L⁻¹MT⁻³ (base unit watt per cubic meter,
+    /// m⁻¹ · kg · s⁻³).
+    dimension: ISQ<
+        N1,     // length
+        P1,     // mass
+        N3,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    units {
+        @watt_per_cubic_meter: prefix!(none); "W/m³", "watt per cubic meter",
+            "watts per cubic meter";
+        @watt_per_cubic_centimeter:
+            prefix!(none) / prefix!(centi) / prefix!(centi) / prefix!(centi); "W/cm³",
+            "watt per cubic centimeter", "watts per cubic centimeter";
+        @watt_per_cubic_millimeter:
+            prefix!(none) / prefix!(milli) / prefix!(milli) / prefix!(milli); "W/mm³",
+            "watt per cubic millimeter", "watts per cubic millimeter";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::power as p;
+        use crate::si::quantities::*;
+        use crate::si::volumetric_power_density as vpd;
+        use crate::si::volume as v;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: VolumetricPowerDensity<V> =  Power::new::<p::watt>(V::one())
+                / Volume::new::<v::cubic_meter>(V::one());
+        }
+
+        #[test]
+        fn check_units() {
+            test::<p::watt, v::cubic_meter, vpd::watt_per_cubic_meter>();
+            test::<p::watt, v::cubic_centimeter, vpd::watt_per_cubic_centimeter>();
+            test::<p::watt, v::cubic_millimeter, vpd::watt_per_cubic_millimeter>();
+
+            fn test<P: p::Conversion<V>, U: v::Conversion<V>, VPD: vpd::Conversion<V>>() {
+                Test::assert_approx_eq(&VolumetricPowerDensity::new::<VPD>(V::one()),
+                    &(Power::new::<P>(V::one()) / Volume::new::<U>(V::one())));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding:

- volumetric power density [Power / Volume, W/m3]
- linear power density [Power / Length, W/m]

- Few new units for HeatFluxDensity. [Power / Area]. 
Maybe it's possible to add an alias ArealPowerDensity => HeatFluxDensity, to have a more generic name for this quantity,
to use in cases where the energy flux is not a flux of thermal energy?