### PR TITLE
Adding universal gas constant and Boltzmann constant as units of measure

### DIFF
--- a/src/si/heat_capacity.rs
+++ b/src/si/heat_capacity.rs
@@ -167,6 +167,8 @@ quantity! {
         @btu_it_per_degree_fahrenheit: 1.899_100_8_E3; "Btu (IT)/°F",
             "British thermal unit (IT) per degree Fahrenheit",
             "British thermal units (IT) per degree Fahrenheit";
+
+        @boltzmann_constant: 1.380_649_E-23; "k", "Boltzmann constant", "Boltzmann constants";
     }
 }
 

--- a/src/si/molar_heat_capacity.rs
+++ b/src/si/molar_heat_capacity.rs
@@ -94,6 +94,8 @@ quantity! {
         @electronvolt_per_kelvin_particle: 6.022_140_76_E23 * 1.602_176_634_E-19;
             "eV/(K · particle)", "electronvolt per kelvin particle",
             "electronvolts per kelvin particle";
+
+        @molar_gas_constant: 8.314_462_618_E0; "R", "molar gas constant", "molar gas constants";
     }
 }
 


### PR DESCRIPTION
Adding molar gas constant R as a unit of measure for molar heat capacity,
and the Boltzmann as unit of measure for heat capacity.

This should simplify using dimensioned constants in equations.
In some problems this constants are "natural" units, for example molar heat capacities of ideal gas Cp and Cv measured in R are small half-integer numbers.