### PR TITLE
feat: Add ton_per_minute and ton_per_day

### DIFF
--- a/src/si/mass.rs
+++ b/src/si/mass.rs
@@ -54,6 +54,7 @@ quantity! {
         @ton_assay: 2.916_667_E-2; "AT", "assay ton", "assay tons";
         @ton_long: 1.016_047_E3; "2240 lb", "long ton", "long tons";
         @ton_short: 9.071_847_E2; "2000 lb", "short ton", "short tons";
-        @ton: 1.0_E3; "t", "ton", "tons"; // ton, metric
+         /// Ton Metric
+        @ton: 1.0_E3; "t", "ton", "tons";
     }
 }

--- a/src/si/mass_rate.rs
+++ b/src/si/mass_rate.rs
@@ -95,8 +95,14 @@ quantity! {
             "short tons per second";
         @ton_short_per_hour: 2.519_957_5_E-1; "2000 lb/h", "short ton per hour",
             "short tons per hour";
-        @ton_per_second: 1.0_E3; "t/s", "ton per second",
-            "tons per second"; // ton per second, metric
+        /// Ton per second, metric.
+        @ton_per_second: 1.0_E3; "t/s", "ton per second", "tons per second";
+        /// Ton per minute, metric.
+        @ton_per_minute: 1.666_666_666_666_666_6_E1; "t/min", "ton per minute", "tons per minute";
+        /// Ton per hour, metric.
+        @ton_per_hour: 2.777777777777778_E-1; "t/h", "ton per hour", "tons per hour";
+        /// Ton per day, metric.
+        @ton_per_day: 1.157_407_407_407_407_4_E-2; "t/d", "ton per day", "tons per day";
     }
 }
 
@@ -165,6 +171,9 @@ mod test {
             test::<m::ton_short, t::second, r::ton_short_per_second>();
             test::<m::ton_short, t::hour, r::ton_short_per_hour>();
             test::<m::ton, t::second, r::ton_per_second>();
+            test::<m::ton, t::minute, r::ton_per_minute>();
+            test::<m::ton, t::hour, r::ton_per_hour>();
+            test::<m::ton, t::day, r::ton_per_day>();
 
             fn test<M: m::Conversion<V>, T: t::Conversion<V>, R: r::Conversion<V>>() {
                 Test::assert_approx_eq(&MassRate::new::<R>(V::one()),


### PR DESCRIPTION
This PR attempts to add the ton_per_minute and ton_per_day units to flow rate.
Regarding the name of ton, I'd like to propose changing it to tonne, to avoid confusion with long and short ton. Or metric_ton. 