### PR TITLE
msrv: Use rust-version key.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "uom"
 version = "0.35.0"
 edition = "2018"
+rust-version = "1.60.0"
 authors = ["Mike Boutin <mike.boutin@gmail.com>"]
 description = "Units of measurement"
 documentation = "https://docs.rs/uom"
@@ -18,9 +19,6 @@ autobenches = true
 
 [package.metadata.docs.rs]
 features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "use_serde"]
-
-[package.metadata]
-msrv = "1.60.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This was added in Rust 1.56 and is supported by the `cargo-msrv` tool as well.