### PR TITLE
Add explicit serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autotests = true
 autobenches = true
 
 [package.metadata.docs.rs]
-features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "use_serde"]
+features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "serde"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -71,13 +71,11 @@ f32 = []
 f64 = []
 si = []
 std = ["num-traits/std"]
+serde = ["dep:serde", "num-rational?/serde", "num-bigint?/serde", "num-complex?/serde"]
 # The try-from feature is deprecated and will be removed in a future release of uom. Functionality
 # previously exposed by the feature is now enabled by default.
 try-from = []
-# The `use_serde` feature exists so that, in the future, other dependency features like num/serde
-# can be added. However, num/serde is currently left out because it has not yet been updated to
-# Serde 1.0. It is also necessary to name the feature something other than `serde` because of a
-# cargo bug: https://github.com/rust-lang/cargo/issues/1286
+# Deprecated alias for the serde feature. Will be removed in a future release of uom (v0.37.0+)
 use_serde = ["serde"]
 # Internal features to include appropriate num-* crates.
 rational-support = ["num-rational"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uom = {
         "complex32", "complex64", # Complex floating point storage types.
         "f32", "f64", # Floating point storage types.
         "si", "std", # Built-in SI system and std library support.
-        "use_serde", # Serde support.
+        "serde", # Serde support.
     ]
 }
 ```
@@ -108,17 +108,9 @@ uom = {
    default.
  * `std` -- Feature to compile with standard library support. Disabling this feature compiles `uom`
    with `no_std`. Enabled by default.
- * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
-   with the [Serde][serde] crate. Disabled by default.
-
-   [Serde][serde] support for the `big*` and `rational*` underlying storage types requires manually
-   enabling the `serde` feature for the `num-rational` and `num-bigint` crates. To do so, you can
-   add one or both of the following lines to your `Cargo.toml`:
-
-   ```toml
-   num-rational = { version = "*", features = ["serde"] }
-   num-bigint = { version = "*", features = ["serde"] }
-   ```
+ * `serde` -- Feature to enable support for serialization and deserialization of quantities with the
+   [Serde][serde] crate. Disabled by default. Replaces the deprecated `use_serde` feature, which will
+   be removed in a future `uom` release (v0.37.0 or later).
 
 [si]: https://jcgm.bipm.org/vim/en/1.16.html
 [serde]: https://serde.rs/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!         "complex32", "complex64", # Complex floating point storage types.
 //!         "f32", "f64", # Floating point storage types.
 //!         "si", "std", # Built-in SI system and std library support.
-//!         "use_serde", # Serde support.
+//!         "serde", # Serde support.
 //!     ]
 //! }
 //! ```
@@ -95,17 +95,8 @@
 //!    default.
 //!  * `std` -- Feature to compile with standard library support. Disabling this feature compiles
 //!    `uom` with `no_std`. Enabled by default.
-//!  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
-//!    with the [Serde][serde] crate. Disabled by default.
-//!
-//!    [Serde][serde] support for the `big*` and `rational*` underlying storage types requires
-//!    manually enabling the `serde` feature for the `num-rational` and `num-bigint` crates. To do
-//!    so, you can add one or both of the following lines to your `Cargo.toml`:
-//!
-//!    ```toml
-//!    num-rational = { version = "*", features = ["serde"] }
-//!    num-bigint = { version = "*", features = ["serde"] }
-//!    ```
+//!  * `serde` -- Feature to enable support for serialization and deserialization of quantities with
+//!    the [Serde][serde] crate. Disabled by default.
 //!
 //! [si]: https://jcgm.bipm.org/vim/en/1.16.html
 //! [serde]: https://serde.rs/

--- a/tests/edition_check/Cargo.toml
+++ b/tests/edition_check/Cargo.toml
@@ -8,4 +8,4 @@ uom = { path = "../.." }
 
 [features]
 default = []
-use_serde = ["uom/use_serde"]
+serde = ["uom/serde"]

--- a/tests/feature_check/Cargo.toml
+++ b/tests/feature_check/Cargo.toml
@@ -7,4 +7,4 @@ uom = { path = "../.." }
 
 [features]
 default = []
-use_serde = ["uom/use_serde"]
+serde = ["uom/serde"]


### PR DESCRIPTION
This revision adds an explicit Cargo feature named `serde`. This feature is almost identical to the old `use_serde` feature, but uses features of Cargo's new feature resolver to automatically enable `serde` features for `num-*` crates as appropriate. The `use_serde` feature is now a (deprecated) alias for this new `serde` feature.

Very few changes were required, since `uom` was already using the (then-implicit) `serde` feature to begin with. I was unable to find an elegant way to warn users specifying `use_serde` to switch to the new feature.

This closes #216.