### PR TITLE
Add defmt::Format support

### DIFF
--- a/.github/workflows/ci-full-test-suite.yml
+++ b/.github/workflows/ci-full-test-suite.yml
@@ -30,7 +30,10 @@ jobs:
           key: ${{ runner.os }}-${{ steps.install-rust.outputs.cachekey }}
 
       - name: Test all crates
-        run: cargo test --all --verbose --features "use_serde"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --verbose --features "use_serde defmt"
 
       - name: Test si
         run: cargo test --verbose --no-default-features --features "f32 si"

--- a/.github/workflows/ci-min-test-matrix.yml
+++ b/.github/workflows/ci-min-test-matrix.yml
@@ -31,4 +31,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Test all crates
-        run: cargo test --all --verbose --features "use_serde"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --verbose --features "use_serde defmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autotests = true
 autobenches = true
 
 [package.metadata.docs.rs]
-features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "use_serde"]
+features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "use_serde", "defmt"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -36,6 +36,7 @@ num-rational = { version = "0.4", optional = true, default-features = false }
 num-bigint = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 num-complex = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true, default-features = false }
+defmt_crate = { package = "defmt", version = "0.3.2", optional = true }
 typenum = "1.13"
 
 [dev-dependencies]
@@ -79,6 +80,9 @@ try-from = []
 # Serde 1.0. It is also necessary to name the feature something other than `serde` because of a
 # cargo bug: https://github.com/rust-lang/cargo/issues/1286
 use_serde = ["serde"]
+
+defmt = ["defmt_crate"]
+
 # Internal features to include appropriate num-* crates.
 rational-support = ["num-rational"]
 bigint-support = ["num-bigint", "num-rational/num-bigint-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ num-rational = { version = "0.4", optional = true, default-features = false }
 num-bigint = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 num-complex = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true, default-features = false }
-defmt_crate = { package = "defmt", version = "0.3.2", optional = true }
+defmt = { version = "0.3.5", optional = true }
 typenum = "1.13"
 
 [dev-dependencies]
@@ -80,8 +80,6 @@ try-from = []
 # Serde 1.0. It is also necessary to name the feature something other than `serde` because of a
 # cargo bug: https://github.com/rust-lang/cargo/issues/1286
 use_serde = ["serde"]
-
-defmt = ["defmt_crate"]
 
 # Internal features to include appropriate num-* crates.
 rational-support = ["num-rational"]

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ See the [examples](examples) directory for more advanced usage:
 
 ## Features
 `uom` has multiple `Cargo` features for controlling available underlying storage types, the
-inclusion of the pre-built [International System of Units][si] (SI), support for [Serde][serde],
-and `no_std` functionality. The features are described below. `f32`, `f64`, `std`, and `si` are
-enabled by default. Features can be cherry-picked by using the `--no-default-features` and
-`--features "..."` flags when compiling `uom` or specifying features in Cargo.toml:
+inclusion of the pre-built [International System of Units][si] (SI), support for [Serde][serde]
+and [defmt][defmt], and `no_std` functionality. The features are described below. `f32`, `f64`, 
+`std`, and `si` are enabled by default. Features can be cherry-picked by using the `--no-default-features` 
+and `--features "..."` flags when compiling `uom` or specifying features in Cargo.toml:
 
 ```toml
 [dependencies]
@@ -91,6 +91,7 @@ uom = {
         "f32", "f64", # Floating point storage types.
         "si", "std", # Built-in SI system and std library support.
         "use_serde", # Serde support.
+        "defmt", # Defmt log support.
     ]
 }
 ```
@@ -110,6 +111,9 @@ uom = {
    with `no_std`. Enabled by default.
  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
    with the [Serde][serde] crate. Disabled by default.
+ * `defmt` -- Feature to make quantities loggable through the defmt framework. Uses the base 
+   units and dimension of a value to show the unit of it. The current implementation is heavy 
+   on the wire, so users may wish to log a value manually.
 
    [Serde][serde] support for the `big*` and `rational*` underlying storage types requires manually
    enabling the `serde` feature for the `num-rational` and `num-bigint` crates. To do so, you can
@@ -122,6 +126,7 @@ uom = {
 
 [si]: https://jcgm.bipm.org/vim/en/1.16.html
 [serde]: https://serde.rs/
+[defmt]: https://knurling.ferrous-systems.com/
 
 ## Design
 Rather than working with [measurement units](https://jcgm.bipm.org/vim/en/1.9.html) (meter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ pub extern crate serde;
 
 #[doc(hidden)]
 #[cfg(feature = "defmt")]
-pub extern crate defmt_crate as defmt;
+pub extern crate defmt;
 
 #[doc(hidden)]
 pub extern crate typenum;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@
 //!    with the [Serde][serde] crate. Disabled by default.
 //!  * `defmt` -- Feature to make quantities loggable through the defmt framework. Uses the base 
 //!    units and dimension of a value to show the unit of it. The current implementation is heavy 
-//!    on the wire, so users may wish to log a value manually.
+//!    on the wire, so users may wish to log a value with an explicit unit through the systems
+//!    `QuantityArguments`.
 //!
 //!    [Serde][serde] support for the `big*` and `rational*` underlying storage types requires
 //!    manually enabling the `serde` feature for the `num-rational` and `num-bigint` crates. To do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@
 //! ## Features
 //! `uom` has multiple `Cargo` features for controlling available underlying storage types, the
 //! inclusion of the pre-built [International System of Units][si] (SI), support for
-//! [Serde][serde], and `no_std` functionality. The features are described below. `f32`, `f64`,
-//! `std`, and `si` are enabled by default. Features can be cherry-picked by using the
+//! [Serde][serde] and [defmt][defmt], and `no_std` functionality. The features are described below.
+//!  `f32`, `f64`, `std`, and `si` are enabled by default. Features can be cherry-picked by using the
 //! `--no-default-features` and `--features "..."` flags when compiling `uom` or specifying
 //! features in Cargo.toml:
 //!
@@ -78,6 +78,7 @@
 //!         "f32", "f64", # Floating point storage types.
 //!         "si", "std", # Built-in SI system and std library support.
 //!         "use_serde", # Serde support.
+//!         "defmt", # Defmt log support.
 //!     ]
 //! }
 //! ```
@@ -97,6 +98,9 @@
 //!    `uom` with `no_std`. Enabled by default.
 //!  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
 //!    with the [Serde][serde] crate. Disabled by default.
+//!  * `defmt` -- Feature to make quantities loggable through the defmt framework. Uses the base 
+//!    units and dimension of a value to show the unit of it. The current implementation is heavy 
+//!    on the wire, so users may wish to log a value manually.
 //!
 //!    [Serde][serde] support for the `big*` and `rational*` underlying storage types requires
 //!    manually enabling the `serde` feature for the `num-rational` and `num-bigint` crates. To do
@@ -109,6 +113,7 @@
 //!
 //! [si]: https://jcgm.bipm.org/vim/en/1.16.html
 //! [serde]: https://serde.rs/
+//! [defmt]: https://knurling.ferrous-systems.com/
 //!
 //! ## Design
 //! Rather than working with [measurement units](https://jcgm.bipm.org/vim/en/1.9.html) (meter,
@@ -227,6 +232,11 @@ pub extern crate num_complex;
 #[doc(hidden)]
 #[cfg(feature = "serde")]
 pub extern crate serde;
+
+#[doc(hidden)]
+#[cfg(feature = "defmt")]
+pub extern crate defmt_crate as defmt;
+
 
 #[doc(hidden)]
 pub extern crate typenum;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,8 @@
 //!    `uom` with `no_std`. Enabled by default.
 //!  * `use_serde` -- Feature to enable support for serialization and deserialization of quantities
 //!    with the [Serde][serde] crate. Disabled by default.
-//!  * `defmt` -- Feature to make quantities loggable through the defmt framework. Uses the base 
-//!    units and dimension of a value to show the unit of it. The current implementation is heavy 
+//!  * `defmt` -- Feature to make quantities loggable through the defmt framework. Uses the base
+//!    units and dimension of a value to show the unit of it. The current implementation is heavy
 //!    on the wire, so users may wish to log a value with an explicit unit through the systems
 //!    `QuantityArguments`.
 //!
@@ -237,7 +237,6 @@ pub extern crate serde;
 #[doc(hidden)]
 #[cfg(feature = "defmt")]
 pub extern crate defmt_crate as defmt;
-
 
 #[doc(hidden)]
 pub extern crate typenum;

--- a/src/system.rs
+++ b/src/system.rs
@@ -1527,6 +1527,27 @@ macro_rules! system {
             {
             }
 
+            #[cfg(feature = "defmt")]
+            impl<D, U, V, N> $crate::defmt::Format for QuantityArguments<D, U, V, N>
+            where
+                D: Dimension + ?Sized,
+                U: Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V> + $crate::defmt::Format,
+                N: Unit + Conversion<V, T = V::T>,
+            {
+                fn format(&self, fmt: $crate::defmt::Formatter) {
+                    // We need this re-export here because of internal workings of the
+                    // defmt::write! macro 
+                    use $crate::defmt as defmt;
+                    let value = from_base::<D, U, V, N>(&self.quantity.value);
+                    $crate::defmt::write!(fmt, "{:?} {}", 
+                        value,
+                        // We always show the full description
+                        if value.is_one() { N::singular() } else { N::plural() },
+                    );
+                }
+            }
+
             macro_rules! format_arguments {
                 ($style:ident) => {
                     impl<D, U, V, N> fmt::$style for QuantityArguments<D, U, V, N>

--- a/src/system.rs
+++ b/src/system.rs
@@ -1001,7 +1001,7 @@ macro_rules! system {
                 }))+
             }
         }
-        
+
         #[cfg(feature = "defmt")]
         impl<D, U, V> $crate::defmt::Format for Quantity<D, U, V>
         where
@@ -1011,7 +1011,7 @@ macro_rules! system {
         {
             fn format(&self, fmt: $crate::defmt::Formatter) {
                 // We need this re-export here because of internal workings of the
-                // defmt::write! macro 
+                // defmt::write! macro
                 use $crate::defmt as defmt;
                 $crate::defmt::write!(fmt, "{:?}", self.value);
                 $(
@@ -1537,10 +1537,10 @@ macro_rules! system {
             {
                 fn format(&self, fmt: $crate::defmt::Formatter) {
                     // We need this re-export here because of internal workings of the
-                    // defmt::write! macro 
+                    // defmt::write! macro
                     use $crate::defmt as defmt;
                     let value = from_base::<D, U, V, N>(&self.quantity.value);
-                    $crate::defmt::write!(fmt, "{:?} {}", 
+                    $crate::defmt::write!(fmt, "{:?} {}",
                         value,
                         // We always show the full description
                         if value.is_one() { N::singular() } else { N::plural() },

--- a/src/system.rs
+++ b/src/system.rs
@@ -1001,6 +1001,28 @@ macro_rules! system {
                 }))+
             }
         }
+        
+        #[cfg(feature = "defmt")]
+        impl<D, U, V> $crate::defmt::Format for Quantity<D, U, V>
+        where
+            D: Dimension + ?Sized,
+            U: Units<V> + ?Sized,
+            V: $crate::num::Num + $crate::Conversion<V> + $crate::defmt::Format,
+        {
+            fn format(&self, fmt: $crate::defmt::Formatter) {
+                // We need this re-export here because of internal workings of the
+                // defmt::write! macro 
+                use $crate::defmt as defmt;
+                $crate::defmt::write!(fmt, "{:?}", self.value);
+                $(
+                    let d = <D::$symbol as $crate::typenum::Integer>::to_i32();
+
+                    if 0 != d {
+                        $crate::defmt::write!(fmt, " {}^{}", U::$name::abbreviation(), d)
+                    }
+                )+
+            }
+        }
 
         impl<D, U, V> $crate::lib::default::Default for Quantity<D, U, V>
         where

--- a/tests/feature_check/Cargo.toml
+++ b/tests/feature_check/Cargo.toml
@@ -8,3 +8,4 @@ uom = { path = "../.." }
 [features]
 default = []
 use_serde = ["uom/use_serde"]
+defmt = ["uom/defmt"]


### PR DESCRIPTION
This is essentially #386 in a trenchcoat (thanks @therealfrauholle!), rebased against the latest upstream `master` and with a minor change to use an implicit `defmt` feature instead of an explicit one.

Closes #385.