### PR TITLE
replace arguments unit with phantomdata to reduce struct size

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -213,7 +213,7 @@ macro_rules! quantity {
             #[inline(always)]
             pub fn new<N>(v: V) -> Self
             where
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 $quantity {
                     dimension: $crate::lib::marker::PhantomData,
@@ -230,7 +230,7 @@ macro_rules! quantity {
             #[inline(always)]
             pub fn get<N>(&self) -> V
             where
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 __system::from_base::<Dimension, U, V, N>(&self.value)
             }
@@ -245,7 +245,7 @@ macro_rules! quantity {
             pub fn floor<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 Self::new::<N>(self.get::<N>().floor())
             }
@@ -260,7 +260,7 @@ macro_rules! quantity {
             pub fn ceil<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 Self::new::<N>(self.get::<N>().ceil())
             }
@@ -275,7 +275,7 @@ macro_rules! quantity {
             pub fn round<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 Self::new::<N>(self.get::<N>().round())
             }
@@ -289,7 +289,7 @@ macro_rules! quantity {
             pub fn trunc<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 Self::new::<N>(self.get::<N>().trunc())
             }
@@ -303,7 +303,7 @@ macro_rules! quantity {
             pub fn fract<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T> + ?Sized,
             {
                 Self::new::<N>(self.get::<N>().fract())
             }
@@ -337,15 +337,16 @@ macro_rules! quantity {
             /// * `N`: Unit.
             #[must_use = "method returns a new object"]
             pub fn format_args<N>(
-                unit: N,
+                #[allow(unused_variables)] unit: N,
                 style: $crate::fmt::DisplayStyle
             ) -> __system::fmt::Arguments<Dimension, N>
             where
-                N: Unit
+                N: Unit + ?Sized
             {
+
                 __system::fmt::Arguments {
                     dimension: $crate::lib::marker::PhantomData,
-                    unit,
+                    _unit: $crate::lib::marker::PhantomData,
                     style,
                 }
             }
@@ -378,16 +379,16 @@ macro_rules! quantity {
             #[must_use = "method returns a new object and does not mutate the original one"]
             pub fn into_format_args<N>(
                 self,
-                unit: N,
+                #[allow(unused_variables)] unit: N,
                 style: $crate::fmt::DisplayStyle
             ) -> __system::fmt::QuantityArguments<Dimension, U, V, N>
             where
-                N: Unit
+                N: Unit + ?Sized,
             {
                 __system::fmt::QuantityArguments {
                     arguments: __system::fmt::Arguments {
                         dimension: $crate::lib::marker::PhantomData,
-                        unit,
+                        _unit: $crate::lib::marker::PhantomData,
                         style,
                     },
                     quantity: self,
@@ -397,7 +398,7 @@ macro_rules! quantity {
 
         impl<N> __system::fmt::Arguments<Dimension, N>
         where
-            N: __system::Unit + Unit,
+            N: __system::Unit + Unit + ?Sized,
         {
             /// Specifies a quantity to display.
             ///

--- a/src/system.rs
+++ b/src/system.rs
@@ -307,7 +307,7 @@ macro_rules! system {
             D: Dimension + ?Sized,
             U: Units<V> + ?Sized,
             V: $crate::Conversion<V>,
-            N: $crate::Conversion<V, T = V::T>,
+            N: $crate::Conversion<V, T = V::T> + ?Sized,
         {
             use $crate::typenum::Integer;
             use $crate::{Conversion, ConversionFactor};
@@ -338,7 +338,7 @@ macro_rules! system {
             D: Dimension + ?Sized,
             U: Units<V> + ?Sized,
             V: $crate::Conversion<V>,
-            N: $crate::Conversion<V, T = V::T>,
+            N: $crate::Conversion<V, T = V::T> + ?Sized,
         {
             use $crate::typenum::Integer;
             use $crate::{Conversion, ConversionFactor};
@@ -1423,10 +1423,10 @@ macro_rules! system {
             pub struct Arguments<D, N>
             where
                 D: Dimension + ?Sized,
-                N: Unit,
+                N: Unit + ?Sized,
             {
                 pub(super) dimension: $crate::lib::marker::PhantomData<D>,
-                pub(super) unit: N,
+                pub(super) _unit: $crate::lib::marker::PhantomData<N>,
                 pub(super) style: DisplayStyle,
             }
 
@@ -1454,7 +1454,7 @@ macro_rules! system {
                 D: Dimension + ?Sized,
                 U: Units<V> + ?Sized,
                 V: Num + Conversion<V>,
-                N: Unit,
+                N: Unit + ?Sized,
             {
                 pub(super) arguments: Arguments<D, N>,
                 pub(super) quantity: Quantity<D, U, V>,
@@ -1463,7 +1463,7 @@ macro_rules! system {
             impl<D, N> $crate::lib::clone::Clone for Arguments<D, N>
             where
                 D: Dimension + ?Sized,
-                N: Unit,
+                N: Unit + ?Sized,
             {
                 fn clone(&self) -> Self {
                     Self {
@@ -1477,7 +1477,7 @@ macro_rules! system {
             impl<D, N> $crate::lib::marker::Copy for Arguments<D, N>
             where
                 D: Dimension + ?Sized,
-                N: Unit,
+                N: Unit + ?Sized,
             {
             }
 
@@ -1486,7 +1486,7 @@ macro_rules! system {
                 D: Dimension + ?Sized,
                 U: Units<V> + ?Sized,
                 V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::clone::Clone,
-                N: Unit,
+                N: Unit + ?Sized,
             {
                 fn clone(&self) -> Self {
                     Self {
@@ -1501,7 +1501,7 @@ macro_rules! system {
                 D: Dimension + ?Sized,
                 U: Units<V> + ?Sized,
                 V: $crate::num::Num + $crate::Conversion<V> + $crate::lib::marker::Copy,
-                N: Unit,
+                N: Unit + ?Sized,
             {
             }
 
@@ -1512,7 +1512,7 @@ macro_rules! system {
                         D: Dimension + ?Sized,
                         U: Units<V> + ?Sized,
                         V: Num + Conversion<V> + fmt::$style,
-                        N: Unit + Conversion<V, T = V::T>,
+                        N: Unit + Conversion<V, T = V::T> + ?Sized,
                     {
                         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                             let value = from_base::<D, U, V, N>(&self.quantity.value);


### PR DESCRIPTION
This reduces the struct size from 1 + sizeof(N) to just 1 Also this get's rid of the warning, that the `unit` field is not read at all