### PR TITLE
Add areal heat capacity quantity

### DIFF
--- a/src/si/areal_heat_capacity.rs
+++ b/src/si/areal_heat_capacity.rs
@@ -1,0 +1,48 @@
+//! Areal heat capacity (base unit joule per square meter kelvin, kg · s⁻² · K⁻¹).
+
+quantity! {
+    /// Areal heat capacity (base unit joule per square meter kelvin, kg · s⁻² · K⁻¹).
+    quantity: ArealHeatCapacity; "areal heat capacity";
+    /// Dimension of areal heat capacity, MT⁻²Th⁻¹(base unit joule per square meter kelvin,
+    /// kg · s⁻² · K⁻¹).
+    dimension: ISQ<
+        Z0,     // length
+        P1,     // mass
+        N2,     // time
+        Z0,     // electric current
+        N1,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    units {
+        @joule_per_square_meter_kelvin: prefix!(none); "J/(m² · K)",
+            "joule per square meter kelvin", "joules per square meter kelvin";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    storage_types! {
+        use crate::num::One;
+        use crate::si::heat_capacity as hc;
+        use crate::si::area as a;
+        use crate::si::quantities::*;
+        use crate::si::areal_heat_capacity as ahc;
+        use crate::tests::Test;
+
+        #[test]
+        fn check_dimension() {
+            let _: ArealHeatCapacity<V> = HeatCapacity::new::<hc::joule_per_kelvin>(V::one())
+                / Area::new::<a::square_meter>(V::one());
+        }
+
+        #[test]
+        fn check_heat_capacity_area_units() {
+            test::<hc::joule_per_kelvin, a::square_meter, ahc::joule_per_square_meter_kelvin>();
+
+            fn test<HC: hc::Conversion<V>, A: a::Conversion<V>, AHC: ahc::Conversion<V>>() {
+                Test::assert_approx_eq(&ArealHeatCapacity::new::<AHC>(V::one()),
+                    &(HeatCapacity::new::<HC>(V::one()) / (Area::new::<A>(V::one()))));
+            }
+        }
+    }
+}

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -56,6 +56,7 @@ system! {
         angular_velocity::AngularVelocity,
         area::Area,
         areal_density_of_states::ArealDensityOfStates,
+        areal_heat_capacity::ArealHeatCapacity,
         areal_mass_density::ArealMassDensity,
         areal_number_density::ArealNumberDensity,
         areal_number_rate::ArealNumberRate,


### PR DESCRIPTION
Added new quantity `ArealHeatCapacity` with base unit `J/(m²·K)`.