### PR TITLE
Conversion now has both a value and a factor type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,13 +408,15 @@ pub enum ConstantOp {
 /// Trait to identify [units][units] which have a [conversion factor][factor].
 ///
 /// ## Generic Parameters
-/// * `V`: Underlying storage type trait is implemented for.
-///
+/// * `T`: The type of the conversion factor. Usually same as `VT`, but for example complex storage types have this as float as it needs `PartialEq`
+/// * `VT`: Underlying storage type trait is implemented for. Does not have to implement `PartialEq`, so its viable for complex data types.
 /// [units]: https://jcgm.bipm.org/vim/en/1.13.html
 /// [factor]: https://jcgm.bipm.org/vim/en/1.24.html
 pub trait Conversion<V> {
     /// Conversion factor type specific to the underlying storage type.
-    type T: ConversionFactor<V>;
+    type T: ConversionFactor<V> + PartialOrd;
+    /// Value type of the underlying type.
+    type VT: ConversionFactor<V> + From<Self::T>;
 
     /// Coefficient portion of [conversion factor](https://jcgm.bipm.org/vim/en/1.24.html) for
     /// converting the given unit. To convert to the base unit for the quantity use `(value +
@@ -436,21 +438,17 @@ pub trait Conversion<V> {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline(always)]
     #[allow(unused_variables)]
-    fn constant(op: ConstantOp) -> Self::T {
-        <Self::T as crate::num::Zero>::zero()
+    fn constant(op: ConstantOp) -> Self::VT {
+        <Self::VT as crate::num::Zero>::zero()
     }
 
     /// Instance [conversion factor](https://jcgm.bipm.org/vim/en/1.24.html).
     ///
     /// Default implementation returns the coefficient: `Self::coefficient()`.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[inline(always)]
-    fn conversion(&self) -> Self::T
+    fn conversion(&self) -> Self::VT
     where
-        Self: Sized,
-    {
-        Self::coefficient()
-    }
+        Self: Sized;
 }
 
 /// Trait representing a [conversion factor][factor].
@@ -461,8 +459,7 @@ pub trait Conversion<V> {
 /// [factor]: https://jcgm.bipm.org/vim/en/1.24.html
 #[allow(unused_qualifications)] // lib:cmp::PartialOrder false positive.
 pub trait ConversionFactor<V>:
-    lib::cmp::PartialOrd
-    + lib::ops::Add<Self, Output = Self>
+    lib::ops::Add<Self, Output = Self>
     + lib::ops::Sub<Self, Output = Self>
     + lib::ops::Mul<Self, Output = Self>
     + lib::ops::Div<Self, Output = Self>
@@ -517,17 +514,18 @@ storage_types! {
 
     impl crate::Conversion<V> for V {
         type T = V;
+        type VT = Self::T;
 
         #[inline(always)]
-        fn constant(op: crate::ConstantOp) -> Self::T {
+        fn constant(op: crate::ConstantOp) -> Self::VT {
             match op {
-                crate::ConstantOp::Add => -<Self::T as crate::num::Zero>::zero(),
-                crate::ConstantOp::Sub => <Self::T as crate::num::Zero>::zero(),
+                crate::ConstantOp::Add => -<Self::VT as crate::num::Zero>::zero(),
+                crate::ConstantOp::Sub => <Self::VT as crate::num::Zero>::zero(),
             }
         }
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             *self
         }
     }
@@ -554,9 +552,10 @@ storage_types! {
 
     impl crate::Conversion<V> for V {
         type T = crate::num::rational::Ratio<V>;
+        type VT = Self::T;
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             (*self).into()
         }
     }
@@ -583,9 +582,10 @@ storage_types! {
 
     impl crate::Conversion<V> for V {
         type T = crate::num::rational::Ratio<V>;
+        type VT = Self::T;
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             self.clone().into()
         }
     }
@@ -612,9 +612,10 @@ storage_types! {
 
     impl crate::Conversion<V> for V {
         type T = V;
+        type VT = Self::T;
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             *self
         }
     }
@@ -637,9 +638,10 @@ storage_types! {
 
     impl crate::Conversion<V> for V {
         type T = V;
+        type VT = Self::T;
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             self.clone()
         }
     }
@@ -665,20 +667,21 @@ storage_types! {
     types: Complex;
     impl crate::Conversion<V> for V {
         type T = VV;
+        type VT = V;
 
         #[inline(always)]
-        fn constant(op: crate::ConstantOp) -> Self::T {
+        fn constant(op: crate::ConstantOp) -> Self::VT {
             match op {
-                crate::ConstantOp::Add => -<Self::T as crate::num::Zero>::zero(),
-                crate::ConstantOp::Sub => <Self::T as crate::num::Zero>::zero(),
+                crate::ConstantOp::Add => -<Self::VT as crate::num::Zero>::zero(),
+                crate::ConstantOp::Sub => <Self::VT as crate::num::Zero>::zero(),
             }
         }
 
         #[inline(always)]
-        fn conversion(&self) -> Self::T {
+        fn conversion(&self) -> Self::VT {
             // Conversion factor is the norm of the number. Scaling with length again yields the
             // same number.
-            self.norm()
+            *self
         }
     }
 
@@ -693,6 +696,18 @@ storage_types! {
             // Conversion by scaling (multiplication with only real number). Scaling a normalized
             // number yields the original number again.
             V::new(self, 0.0)
+        }
+    }
+
+    impl crate::ConversionFactor<V> for V {
+        #[inline(always)]
+        fn powi(self, e: i32) -> Self {
+            crate::num::complex::Complex::powi(&self,e)
+        }
+
+        #[inline(always)]
+        fn value(self) -> V {
+            self
         }
     }
 }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -132,7 +132,7 @@ macro_rules! quantity {
         ///
         /// [units]: https://jcgm.bipm.org/vim/en/1.13.html
         /// [factor]: https://jcgm.bipm.org/vim/en/1.24.html
-        pub trait Conversion<V>: Unit + $crate::Conversion<V, T = <V as $crate::Conversion<V>>::T>
+        pub trait Conversion<V>: Unit + $crate::Conversion<V, T = <V as $crate::Conversion<V>>::T, VT = <V as $crate::Conversion<V>>::VT>
         where
             V: $crate::Conversion<V>,
         {
@@ -213,7 +213,7 @@ macro_rules! quantity {
             #[inline(always)]
             pub fn new<N>(v: V) -> Self
             where
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 $quantity {
                     dimension: $crate::lib::marker::PhantomData,
@@ -230,7 +230,7 @@ macro_rules! quantity {
             #[inline(always)]
             pub fn get<N>(&self) -> V
             where
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 __system::from_base::<Dimension, U, V, N>(&self.value)
             }
@@ -245,7 +245,7 @@ macro_rules! quantity {
             pub fn floor<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 Self::new::<N>(self.get::<N>().floor())
             }
@@ -260,7 +260,7 @@ macro_rules! quantity {
             pub fn ceil<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 Self::new::<N>(self.get::<N>().ceil())
             }
@@ -275,7 +275,7 @@ macro_rules! quantity {
             pub fn round<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 Self::new::<N>(self.get::<N>().round())
             }
@@ -289,7 +289,7 @@ macro_rules! quantity {
             pub fn trunc<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 Self::new::<N>(self.get::<N>().trunc())
             }
@@ -303,7 +303,7 @@ macro_rules! quantity {
             pub fn fract<N>(self) -> Self
             where
                 V: $crate::num::Float,
-                N: Unit + $crate::Conversion<V, T = V::T>,
+                N: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>,
             {
                 Self::new::<N>(self.get::<N>().fract())
             }

--- a/src/si/angle.rs
+++ b/src/si/angle.rs
@@ -127,7 +127,7 @@ where
     D: crate::si::Dimension + ?Sized,
     U: crate::si::Units<V> + ?Sized,
     V: crate::num::Float + crate::Conversion<V>,
-    radian: crate::Conversion<V, T = V::T>,
+    radian: crate::Conversion<V, T = V::T, VT = V::VT>,
 {
     /// Computes the four quadrant arctangent of self (y) and other (x).
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/src/si/ratio.rs
+++ b/src/si/ratio.rs
@@ -38,8 +38,8 @@ impl<U, V> Ratio<U, V>
 where
     U: crate::si::Units<V> + ?Sized,
     V: crate::num::Float + crate::Conversion<V>,
-    radian: crate::Conversion<V, T = V::T>,
-    ratio: crate::Conversion<V, T = V::T>,
+    radian: crate::Conversion<V, T = V::T, VT = V::VT>,
+    ratio: crate::Conversion<V, T = V::T, VT = V::VT>,
 {
     /// Computes the value of the inverse cosine of the ratio.
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -82,8 +82,8 @@ impl<U, V> crate::lib::convert::TryFrom<Time<U, V>> for Duration
 where
     U: crate::si::Units<V> + ?Sized,
     V: crate::num::Num + crate::Conversion<V> + PartialOrd + ToPrimitive,
-    second: crate::Conversion<V, T = V::T>,
-    nanosecond: crate::Conversion<V, T = V::T>,
+    second: crate::Conversion<V, T = V::T, VT = V::VT>,
+    nanosecond: crate::Conversion<V, T = V::T, VT = V::VT>,
 {
     type Error = TryFromError;
 
@@ -117,8 +117,8 @@ impl<U, V> crate::lib::convert::TryFrom<Duration> for Time<U, V>
 where
     U: crate::si::Units<V> + ?Sized,
     V: crate::num::Num + crate::Conversion<V> + FromPrimitive,
-    second: crate::Conversion<V, T = V::T>,
-    nanosecond: crate::Conversion<V, T = V::T>,
+    second: crate::Conversion<V, T = V::T, VT = V::VT>,
+    nanosecond: crate::Conversion<V, T = V::T, VT = V::VT>,
 {
     type Error = TryFromError;
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -163,7 +163,7 @@ macro_rules! system {
             ///
             /// Base unit.
             #[allow(non_camel_case_types)]
-            type $name: Unit + $crate::Conversion<V, T = V::T>;)+
+            type $name: Unit + $crate::Conversion<V, T = V::T, VT = V::VT>;)+
         }
 
         /// Trait to identify [measurement units][measurement] of individual
@@ -307,7 +307,7 @@ macro_rules! system {
             D: Dimension + ?Sized,
             U: Units<V> + ?Sized,
             V: $crate::Conversion<V>,
-            N: $crate::Conversion<V, T = V::T>,
+            N: $crate::Conversion<V, T = V::T, VT = V::VT>,
         {
             use $crate::typenum::Integer;
             use $crate::{Conversion, ConversionFactor};
@@ -318,10 +318,10 @@ macro_rules! system {
             let n_cons = N::constant($crate::ConstantOp::Sub);
 
             if n_coef < f {
-                (v * (f / n_coef) - n_cons).value()
+                (v * (f / n_coef).into() - n_cons.into()).value()
             }
             else {
-                (v / (n_coef / f) - n_cons).value()
+                (v / (n_coef / f).into() - n_cons.into()).value()
             }
         }
 
@@ -338,7 +338,7 @@ macro_rules! system {
             D: Dimension + ?Sized,
             U: Units<V> + ?Sized,
             V: $crate::Conversion<V>,
-            N: $crate::Conversion<V, T = V::T>,
+            N: $crate::Conversion<V, T = V::T, VT= V::VT>,
         {
             use $crate::typenum::Integer;
             use $crate::{Conversion, ConversionFactor};
@@ -349,10 +349,10 @@ macro_rules! system {
             let n_cons = N::constant($crate::ConstantOp::Add);
 
             if n_coef >= f {
-                ((v + n_cons) * (n_coef / f)).value()
+                ((v + n_cons.into()) * (n_coef / f).into()).value()
             }
             else {
-                (((v + n_cons) * n_coef) / f).value()
+                (((v + n_cons.into()) * n_coef.into()) / f.into()).value()
             }
         }
 
@@ -376,8 +376,8 @@ macro_rules! system {
             use $crate::typenum::Integer;
             use $crate::{Conversion, ConversionFactor};
 
-            (v.conversion() $(* Ur::$name::coefficient().powi(D::$symbol::to_i32())
-                    / Ul::$name::coefficient().powi(D::$symbol::to_i32()))+)
+            (v.conversion() $(* Ur::$name::coefficient().powi(D::$symbol::to_i32()).into()
+                    / Ul::$name::coefficient().powi(D::$symbol::to_i32()).into())+)
                 .value()
         }}
 
@@ -1512,7 +1512,7 @@ macro_rules! system {
                         D: Dimension + ?Sized,
                         U: Units<V> + ?Sized,
                         V: Num + Conversion<V> + fmt::$style,
-                        N: Unit + Conversion<V, T = V::T>,
+                        N: Unit + Conversion<V, T = V::T, VT = V::VT>,
                     {
                         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                             let value = from_base::<D, U, V, N>(&self.quantity.value);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -145,6 +145,7 @@ macro_rules! unit {
 
             $(impl $crate::Conversion<V> for super::$unit {
                 type T = V;
+                type VT = V;
 
                 #[inline(always)]
                 #[allow(clippy::inconsistent_digit_grouping)]
@@ -155,8 +156,13 @@ macro_rules! unit {
                 #[inline(always)]
                 #[allow(unused_variables)]
                 #[allow(clippy::inconsistent_digit_grouping)]
-                fn constant(op: $crate::ConstantOp) -> Self::T {
+                fn constant(op: $crate::ConstantOp) -> Self::VT {
                     unit!(@constant op $($conversion),+)
+                }
+
+                #[inline(always)]
+                fn conversion(&self) -> Self::VT {
+                    unit!(@coefficient $($conversion),+)
                 }
             }
 
@@ -174,6 +180,7 @@ macro_rules! unit {
 
             $(impl $crate::Conversion<V> for super::$unit {
                 type T = T;
+                type VT = T;
 
                 #[inline(always)]
                 fn coefficient() -> Self::T {
@@ -182,8 +189,13 @@ macro_rules! unit {
 
                 #[inline(always)]
                 #[allow(unused_variables)]
-                fn constant(op: $crate::ConstantOp) -> Self::T {
+                fn constant(op: $crate::ConstantOp) -> Self::VT {
                     from_f64(unit!(@constant op $($conversion),+))
+                }
+
+                #[inline(always)]
+                fn conversion(&self) -> Self::VT {
+                    from_f64(unit!(@coefficient $($conversion),+))
                 }
             }
 
@@ -206,6 +218,7 @@ macro_rules! unit {
 
             $(impl $crate::Conversion<V> for super::$unit {
                 type T = T;
+                type VT = T;
 
                 #[inline(always)]
                 fn coefficient() -> Self::T {
@@ -214,8 +227,13 @@ macro_rules! unit {
 
                 #[inline(always)]
                 #[allow(unused_variables)]
-                fn constant(op: $crate::ConstantOp) -> Self::T {
+                fn constant(op: $crate::ConstantOp) -> Self::VT {
                     from_f64(unit!(@constant op $($conversion),+))
+                }
+
+                #[inline(always)]
+                fn conversion(&self) -> Self::VT {
+                    from_f64(unit!(@coefficient $($conversion),+))
                 }
             }
 
@@ -232,6 +250,7 @@ macro_rules! unit {
 
             $(impl $crate::Conversion<V> for super::$unit {
                 type T = V;
+                type VT = V;
 
                 #[inline(always)]
                 fn coefficient() -> Self::T {
@@ -240,8 +259,13 @@ macro_rules! unit {
 
                 #[inline(always)]
                 #[allow(unused_variables)]
-                fn constant(op: $crate::ConstantOp) -> Self::T {
+                fn constant(op: $crate::ConstantOp) -> Self::VT {
                     from_f64(unit!(@constant op $($conversion),+))
+                }
+
+                #[inline(always)]
+                fn conversion(&self) -> Self::VT {
+                    from_f64(unit!(@coefficient $($conversion),+))
                 }
             }
 
@@ -253,6 +277,7 @@ macro_rules! unit {
 
             $(impl $crate::Conversion<V> for super::$unit {
                 type T = VV;
+                type VT = V;
 
                 #[inline(always)]
                 #[allow(clippy::inconsistent_digit_grouping)]
@@ -263,8 +288,13 @@ macro_rules! unit {
                 #[inline(always)]
                 #[allow(unused_variables)]
                 #[allow(clippy::inconsistent_digit_grouping)]
-                fn constant(op: $crate::ConstantOp) -> Self::T {
-                    unit!(@constant op $($conversion),+)
+                fn constant(op: $crate::ConstantOp) -> Self::VT {
+                    (unit!(@constant op $($conversion),+)).into()
+                }
+
+                #[inline(always)]
+                fn conversion(&self) -> Self::VT {
+                    (unit!(@coefficient $($conversion),+)).into()
                 }
             }
 


### PR DESCRIPTION
Initially, `ConversionFactor` and thus `Conversion::T` requred `PartialEq`. This makes sense for the conversion factor itself (i.e. scaling across units), however it breaks once you introduce complex numbers.

Those can *still* be scaled just like normal numbers - you essentially just increase or decrese a vector length, but the conversion function cannot compare them - "Z_1 < Z_2" is not trivially decidable.

It is, however, also not needed - unit scales are just that - scalars that scale. And those can be easily compared.

This commit seperates `Conversion::T` into `Conversion::VT` and `Conversion::T` and moves the `PartialEq` requirements from `ConversionFactor` into `Conversion::TT` directly.

This requires a lot of trait bounds added down the line, so im not 100% that this does not break anything down the line.

There might be a nicer way to go about this, but i haven't found any.

closes #452