### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,32 @@ operations:
 extern crate uom;
 
 use uom::si::f32::*;
-use uom::si::length::kilometer;
-use uom::si::time::second;
+use uom::si::length::{kilometer, meter};
+use uom::si::time::{minute, second};
+use uom::si::velocity::meter_per_second;
 
 fn main() {
+    // Create quantities
     let length = Length::new::<kilometer>(5.0);
     let time = Time::new::<second>(15.0);
     let velocity/*: Velocity*/ = length / time;
     let _acceleration = calc_acceleration(velocity, time);
     //let error = length + time; // error[E0308]: mismatched types
+
+    // Perfrom unit conversions
+    assert_eq!(length.get::<meter>(), 5_000.0);
+    assert_eq!(time.get::<minute>(), 0.25);
+
+    // Print results of simple formulas using different output units.
+    let m = Length::format_args(meter, Abbreviation); // Re-usable format arguments for quantities.
+    let s = Time::format_args(second, Abbreviation);
+
+    println!(
+      "{} / {} = {}",
+      m.with(length),
+      s.with(time),
+      velocity.into_format_args(meter_per_second, Abbreviation) // One-off quantity formatting.
+    );
 }
 
 fn calc_acceleration(velocity: Velocity, time: Time) -> Acceleration {

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ fn main() {
     assert_eq!(length.get::<meter>(), 5_000.0);
     assert_eq!(time.get::<minute>(), 0.25);
 
-    // Print results of simple formulas using different output units.
-    let m = Length::format_args(meter, Abbreviation); // Re-usable format arguments for quantities.
+    // Setup re-usable format arguments for quantities
+    let m = Length::format_args(meter, Abbreviation);
     let s = Time::format_args(second, Abbreviation);
 
+    // Print results of simple formulas using different output units.
     println!(
       "{} / {} = {}",
       m.with(length),

--- a/examples/si.rs
+++ b/examples/si.rs
@@ -2,17 +2,22 @@
 
 use uom::fmt::DisplayStyle::Abbreviation;
 use uom::si::f32::*;
-use uom::si::length::{centimeter, kilometer, meter};
-use uom::si::time::second;
+use uom::si::length::{centimeter, kilometer, meter, millimeter};
+use uom::si::time::{minute, second};
 use uom::si::velocity::{kilometer_per_second, meter_per_second};
 
 fn main() {
     // Setup length and time quantities using different units.
     let l1 = Length::new::<meter>(15.0);
     let l2 = Length::new::<centimeter>(10.0);
-    let t1 = Time::new::<second>(50.0);
+    let t1 = Time::new::<second>(60.0);
     let v1 = l1 / t1;
     //let error = l1 + t1; // error[E0308]: mismatched types
+
+    // Perfrom unit conversions
+    assert_eq!(l1.get::<centimeter>().round(), 1_500.0);
+    assert_eq!(l2.get::<millimeter>().round(), 100.0);
+    assert_eq!(t1.get::<minute>().round(), 1.0);
 
     // Setup re-usable format arguments.
     let m = Length::format_args(meter, Abbreviation);


### PR DESCRIPTION
While first using uom, I found it difficult to get values back out of quantities for plotting. It took longer than I'd like to admit to find the get() function, as it isn't used in any examples or README.

I've updated README.md & si.rs with some examples of get() to make it more obvious.