### PR TITLE
docs: Replace relative URL by Rust item links

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -121,7 +121,7 @@ macro_rules! quantity {
         pub type $quantity<U, V> = __system::Quantity<Dimension, U, V>;
 
         /// Marker trait to identify measurement units for the quantity. See
-        /// [`Unit`](../trait.Unit.html).
+        /// [`Unit`](__system::Unit).
         pub trait Unit: __system::Unit {}
 
         /// Trait to identify [units][units] which have a [conversion factor][factor] for the
@@ -314,7 +314,7 @@ macro_rules! quantity {
             /// # Notes
             /// The return value of this method cannot be used to print directly, but is instead
             /// used to format quantities and can be reused; see
-            /// [Arguments::with](../fmt/struct.Arguments.html#method.with) and the examples below.
+            /// [`Arguments::with`](super::fmt::Arguments::with()) and the examples below.
             ///
             /// If you do not need to format multiple quantities, consider using
             /// [`into_format_args`](#method.into_format_args) instead.

--- a/src/si/mod.rs
+++ b/src/si/mod.rs
@@ -160,14 +160,14 @@ system! {
     }
 }
 
-/// [`Quantity`](struct.Quantity.html) type aliases using the default base units and parameterized
+/// [`Quantity`] type aliases using the default base units and parameterized
 /// on the underlying storage type.
 pub mod quantities {
     ISQ!(crate::si);
 }
 
 storage_types! {
-    /// [`Quantity`](struct.Quantity.html) type aliases using the default base units.
+    /// [`Quantity`](crate::si::Quantity) type aliases using the default base units.
     pub types: All;
 
     ISQ!(crate::si, V);

--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -69,15 +69,13 @@ pub enum TryFromError {
 
 /// Attempt to convert the given `Time` to a `Duration`.
 ///
-/// For possible failure modes see [`TryFromError`][TryFromError].
+/// For possible failure modes see [`TryFromError`].
 ///
 /// ## Notes
 ///
 /// The `Duration` to `Time` conversion is tested to be accurate to within 1 nanosecond (to allow
 /// for floating point rounding error). If greater precision is needed, consider using a different
 /// underlying storage type or avoiding the conversion altogether.
-///
-/// [TryFromError]: enum.TryFromError.html
 impl<U, V> crate::lib::convert::TryFrom<Time<U, V>> for Duration
 where
     U: crate::si::Units<V> + ?Sized,
@@ -104,15 +102,13 @@ where
 
 /// Attempt to convert the given `Duration` to a `Time`.
 ///
-/// For possible failure modes, see [`TryFromError`][TryFromError].
+/// For possible failure modes, see [`TryFromError`]
 ///
 /// ## Notes
 ///
 /// The `Duration` to `Time` conversion is tested to be accurate to within 100 nanoseconds (to
 /// allow for floating point rounding error). If greater precision is needed, consider using a
 /// different underlying storage type or avoiding the conversion altogether.
-///
-/// [TryFromError]: enum.TryFromError.html
 impl<U, V> crate::lib::convert::TryFrom<Duration> for Time<U, V>
 where
     U: crate::si::Units<V> + ?Sized,

--- a/src/system.rs
+++ b/src/system.rs
@@ -251,8 +251,8 @@ macro_rules! system {
         /// * <https://jcgm.bipm.org/vim/en/1.1.html>
         ///
         /// ## Generic Parameters
-        /// * `D`: Quantity dimension. See [`Dimension`](./trait.Dimension.html).
-        /// * `U`: Quantity base units. See [`Units`](./trait.Units.html).
+        /// * `D`: Quantity dimension. See [`Dimension`].
+        /// * `U`: Quantity base units. See [`Units`].
         /// * `V`: Quantity value underlying storage type.
         #[repr(transparent)]
         pub struct Quantity<D, U, V>
@@ -261,10 +261,10 @@ macro_rules! system {
             U: Units<V> + ?Sized,
             V: $crate::num::Num + $crate::Conversion<V>,
         {
-            /// Quantity dimension. See [`Dimension`](./trait.Dimension.html).
+            /// Quantity dimension. See [`Dimension`].
             pub dimension: $crate::lib::marker::PhantomData<D>,
 
-            /// Quantity base units. See [`Units`](./trait.Units.html).
+            /// Quantity base units. See [`Units`].
             pub units: $crate::lib::marker::PhantomData<U>,
 
             /// Quantity value stored in the base units for the quantity.
@@ -1536,10 +1536,10 @@ macro_rules! system {
             format_arguments!(UpperHex);
         }
 
-        /// Macro to implement [`quantity`](si/struct.Quantity.html) type aliases for a specific
+        /// Macro to implement [`Quantity`] type aliases for a specific
         /// [system of units][units] and value storage type.
         ///
-        /// * `$system`: Path to the module where the [`system!`](macro.system.html) macro was run
+        /// * `$system`: Path to the module where the [`system!`] macro was run
         ///   (e.g. `uom::si`).
         /// * `$V`: Underlying value storage type (e.g. `f32`).
         /// * `$U`: Optional. Base units. Pass as a tuple with the desired units: (e.g. `(meter,
@@ -1622,7 +1622,7 @@ macro_rules! system {
             ($path:path) => {
                 use $path as __system;
 
-                $(/// [`Quantity`](struct.Quantity.html) type alias using the default base units
+                $(/// [`Quantity`](crate::si::Quantity) type alias using the default base units
                 /// parameterized on the underlying storage type.
                 ///
                 /// ## Generic Parameters
@@ -1634,7 +1634,7 @@ macro_rules! system {
             ($path:path, $V:ty) => {
                 use $path as __system;
 
-                $(/// [`Quantity`](struct.Quantity.html) type alias using the default base units.
+                $(/// [`Quantity`](crate::si::Quantity) type alias using the default base units.
                 #[allow(dead_code)]
                 #[allow(unused_qualifications)]
                 pub type $quantity = __system::$module::$quantity<__system::$units<$V>, $V>;)+
@@ -1661,7 +1661,7 @@ macro_rules! system {
         /// [quantities]: https://jcgm.bipm.org/vim/en/1.3.html
         pub type Units = dyn __system::Units<$V, $($name = __system::$name::$U,)+>;
 
-        $(/// [`Quantity`](struct.Quantity.html) type alias using the given base units.
+        $(/// [`Quantity`](crate::si::Quantity) type alias using the given base units.
         #[allow(dead_code)]
         #[allow(unused_qualifications)]
         pub type $quantity = __system::$module::$quantity<Units, $V>;)+

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -7,9 +7,9 @@
 /// quickly be defined without requiring a release. [Pull requests][pr] to add new units upstream
 /// area always greatly appreciated.
 ///
-/// * `$system`: Path to the module where the [`system!`](macro.system.html) macro was run (e.g.
+/// * `$system`: Path to the module where the [`system!`] macro was run (e.g.
 ///   `uom::si`).
-/// * `quantity`: Path to the module where the [`quantity!`](macro.quantity.html) macro was run
+/// * `quantity`: Path to the module where the [`quantity!`] macro was run
 ///   (e.g. `uom::si::length`).
 /// * `$unit`: Unit name (e.g. `meter`, `foot`).
 /// * `$conversion`: Conversion (coefficient and constant factor) from the unit to the base unit of


### PR DESCRIPTION
Some links in the documenation are broken. `cargo doc` will resolve item names when used in markdown links. The tool will report unresolved links as warning so that they can be fixed. Replace any relative URL by such item link. See https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html