### PR TITLE
Fix NIST Special Publication 811 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ at your option.
 [BIPM]: https://www.bipm.org/en/about-us/
 [brochure]: https://www.bipm.org/en/publications/si-brochure/
 [si]: https://jcgm.bipm.org/vim/en/1.16.html
-[nist811]: https://www.nist.gov/pml/nist-guide-si-appendix-b9-factors-units-listed-kind-quantity-or-field-science
+[nist811]: https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9


### PR DESCRIPTION
I saw that the NIST Special Publication 811 link wasn't working and updated it to a working version: https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9.

