### PR TITLE
Feat implemented support for schemars via a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,25 +18,43 @@ autotests = true
 autobenches = true
 
 [package.metadata.docs.rs]
-features = ["usize", "u32", "u64", "isize", "i32", "i64", "bigint", "biguint", "rational", "rational32", "rational64", "bigrational", "serde"]
+features = [
+    "usize",
+    "u32",
+    "u64",
+    "isize",
+    "i32",
+    "i64",
+    "bigint",
+    "biguint",
+    "rational",
+    "rational32",
+    "rational64",
+    "bigrational",
+    "serde",
+    "schemars",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [workspace]
-members = [
-    "tests/feature_check",
-    "uom-macros",
-    "tests/edition_check",
-]
+members = ["tests/feature_check", "uom-macros", "tests/edition_check"]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 num-rational = { version = "0.4", optional = true, default-features = false }
-num-bigint = { version = "0.4", optional = true, default-features = false, features = ["std"] }
-num-complex = { version = "0.4", optional = true, default-features = false, features = ["std"] }
+num-bigint = { version = "0.4", optional = true, default-features = false, features = [
+    "std",
+] }
+num-complex = { version = "0.4", optional = true, default-features = false, features = [
+    "std",
+] }
 serde = { version = "1.0", optional = true, default-features = false }
 typenum = "1.13"
+schemars = { version = "0.8", optional = true, default-features = false, features = [
+    "derive",
+] }
 
 [dev-dependencies]
 approx = "0.5"
@@ -71,7 +89,12 @@ f32 = []
 f64 = []
 si = []
 std = ["num-traits/std"]
-serde = ["dep:serde", "num-rational?/serde", "num-bigint?/serde", "num-complex?/serde"]
+serde = [
+    "dep:serde",
+    "num-rational?/serde",
+    "num-bigint?/serde",
+    "num-complex?/serde",
+]
 # The try-from feature is deprecated and will be removed in a future release of uom. Functionality
 # previously exposed by the feature is now enabled by default.
 try-from = []
@@ -81,6 +104,7 @@ use_serde = ["serde"]
 rational-support = ["num-rational"]
 bigint-support = ["num-bigint", "num-rational/num-bigint-std"]
 complex-support = ["num-complex"]
+schemars = ["dep:schemars"]
 
 [[example]]
 name = "base"

--- a/src/features.rs
+++ b/src/features.rs
@@ -65,6 +65,21 @@ macro_rules! serde {
     ($($tt:tt)*) => {};
 }
 
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "schemars")]
+macro_rules! schemars {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Does not expand the given block of code when `uom` is compiled without the `serde` feature.
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "schemars"))]
+macro_rules! schemars {
+    ($($tt:tt)*) => {};
+}
+
 /// Expands the given block of code when `uom` is compiled with the `si` feature.
 #[doc(hidden)]
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,10 @@ pub extern crate num_complex;
 pub extern crate serde;
 
 #[doc(hidden)]
+#[cfg(feature = "schemars")]
+pub extern crate schemars;
+
+#[doc(hidden)]
 pub extern crate typenum;
 
 #[cfg(all(

--- a/src/system.rs
+++ b/src/system.rs
@@ -1379,6 +1379,28 @@ macro_rules! system {
             }
         }}
 
+        schemars! {
+            impl<D, U, V> $crate::schemars::JsonSchema for Quantity<D, U, V>
+            where
+                D: Dimension + ?Sized,
+                U: Units<V> + ?Sized,
+                V: $crate::num::Num + $crate::Conversion<V> + $crate::schemars::JsonSchema
+            {
+                fn schema_name() -> String {
+                    "Quantity".to_owned()
+                }
+
+                fn json_schema(_gen: &mut $crate::schemars::gen::SchemaGenerator) -> $crate::schemars::schema::Schema {
+                    use $crate::schemars::schema::{InstanceType, SchemaObject};
+
+                    SchemaObject {
+                        instance_type: Some(InstanceType::Number.into()),
+                        ..Default::default()
+                    }.into()
+                }
+            }
+        }
+
         /// Utilities for formatting and printing quantities.
         pub mod fmt {
             use $crate::lib::fmt;


### PR DESCRIPTION
I've implemented the `JsonSchema` trait from the [schemars](https://crates.io/crates/schemars) crate.
I'm using serde + schemars in my project to generate a json schema so the users can easily create configs.
As i've switched a lot of my structs to use `uom` deriving the `JsonSchema` trait no longer worked.

I think supporting `schemars` would make a lot of sense for `uom`.
As `uom` already supports `serde` this addition would make building api's easier as you could simply generate your schema by deriving the trait.

My implementation of the Trait is pretty simple and covers the minimum.
I don't really like the schema name to be hard coded but i didn't know how i could set it automatically to eg. `Length`, `Mass`, etc.

Would be nice to get this feature merged :)
Happy for feedback and comments
