### PR TITLE
feat: [wip] ordered-float feature options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +303,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "ordered-float",
  "quickcheck",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ num-bigint = { version = "0.4", optional = true, default-features = false, featu
 num-complex = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 serde = { version = "1.0", optional = true, default-features = false }
 typenum = "1.13"
+ordered-float = { version = "4.5.0", optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 approx = "0.5"
@@ -67,6 +68,10 @@ rational64 = ["rational-support"]
 bigrational = ["bigint-support"]
 complex32 = ["complex-support"]
 complex64 = ["complex-support"]
+orderedf32 = ["ordered-float-support"]
+orderedf64 = ["ordered-float-support"]
+notnanf32 = ["ordered-float-support"]
+notnanf64 = ["ordered-float-support"]
 f32 = []
 f64 = []
 si = []
@@ -81,6 +86,7 @@ use_serde = ["serde"]
 rational-support = ["num-rational"]
 bigint-support = ["num-bigint", "num-rational/num-bigint-std"]
 complex-support = ["num-complex"]
+ordered-float-support = ["ordered-float"]
 
 [[example]]
 name = "base"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,8 @@
     feature = "bigint", feature = "biguint",
     feature = "rational", feature = "rational32", feature = "rational64", feature = "bigrational",
     feature = "complex32", feature = "complex64",
+    feature = "orderedf32", feature = "orderedf64",
+    feature = "notnanf32", feature = "notnanf64",
     feature = "f32", feature = "f64", )))]
 compile_error!("A least one underlying storage type must be enabled. See the features section of \
     uom documentation for available underlying storage type options.");
@@ -216,6 +218,10 @@ pub extern crate num_rational;
 pub extern crate num_complex;
 
 #[doc(hidden)]
+#[cfg(feature = "ordered-float-support")]
+pub extern crate ordered_float;
+
+#[doc(hidden)]
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
@@ -224,7 +230,7 @@ pub extern crate typenum;
 
 #[cfg(all(
     test,
-    any(feature = "f32", feature = "f64", feature = "complex32", feature = "complex64")
+    any(feature = "f32", feature = "f64", feature = "complex32", feature = "complex64", feature = "orderedf32", feature = "orderedf64", feature="notnanf32", feature="notnanf64")
 ))]
 #[macro_use]
 extern crate approx;
@@ -292,6 +298,15 @@ pub mod num {
     #[cfg(feature = "complex-support")]
     pub mod complex {
         pub use num_complex::*;
+    }
+
+    #[cfg(feature = "ordered-float-support")]
+    pub mod ordered_float {
+        pub use ordered_float::*;
+        pub type Orderedf32 = OrderedFloat<f32>;
+        pub type Orderedf64 = OrderedFloat<f64>;
+        pub type NotNanf32 = NotNan<f32>;
+        pub type NotNanf64 = NotNan<f64>;
     }
 }
 
@@ -695,6 +710,83 @@ storage_types! {
             V::new(self, 0.0)
         }
     }
+}
+
+
+storage_types! {
+    types: OrderedFloat;
+
+    impl crate::Conversion<Self> for V {
+        type T = VV;
+
+        #[inline(always)]
+        fn constant(op: crate::ConstantOp) -> Self::T {
+            match op {
+                crate::ConstantOp::Add => -<Self::T as crate::num::Zero>::zero(),
+                crate::ConstantOp::Sub => <Self::T as crate::num::Zero>::zero(),
+            }
+        }
+
+        #[inline(always)]
+        fn conversion(&self) -> Self::T {
+            self.0
+        }
+    }
+
+    impl crate::ConversionFactor<V> for VV {
+        #[inline(always)]
+        fn powi(self, e: i32) -> Self {
+            <Self as crate::num::Float>::powi(self, e)
+        }
+
+        #[inline(always)]
+        fn value(self) -> V {
+            ordered_float::OrderedFloat::<VV>(self)
+        }
+    }
+
+    impl crate::ConstZero for V {
+        const ZERO: Self = ordered_float::OrderedFloat::<VV>(0.0);
+    }
+}
+
+storage_types! {
+    types: NotNan;
+
+    impl crate::Conversion<Self> for V {
+        type T = VV;
+
+        #[inline(always)]
+        fn constant(op: crate::ConstantOp) -> Self::T {
+            match op {
+                crate::ConstantOp::Add => -<Self::T as crate::num::Zero>::zero(),
+                crate::ConstantOp::Sub => <Self::T as crate::num::Zero>::zero(),
+            }
+        }
+
+        #[inline(always)]
+        fn conversion(&self) -> Self::T {
+            self.into_inner()
+        }
+    }
+
+    impl crate::ConversionFactor<V> for VV {
+        #[inline(always)]
+        fn powi(self, e: i32) -> Self {
+            <Self as crate::num::Float>::powi(self, e)
+        }
+
+        #[inline(always)]
+        fn value(self) -> V {
+            ordered_float::NotNan::new(self).unwrap()
+        }
+    }
+
+    // can't provide this since ::new().unwrap() is not const, but unsafe is forbidden.
+    //impl crate::ConstZero for V {
+    //    const ZERO: Self = notnan_unwrap(ordered_float::NotNan::new(0.0));
+    //}
+
 }
 
 /// Utilities for formatting and printing quantities.

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -115,6 +115,37 @@ macro_rules! storage_types {
             pub type VV = f64;
             $($tt)*));
     };
+    (@type ($(#[$attr:meta])*) @$M:ident Orderedf32 ($($tt:tt)*)) => {
+        storage_type_orderedf32!(($(#[$attr])*) @$M (
+            /// Inner storage type.
+            #[allow(dead_code)]
+            pub type VV = f32;
+            $($tt)*));
+    };
+    (@type ($(#[$attr:meta])*) @$M:ident Orderedf64 ($($tt:tt)*)) => {
+        storage_type_orderedf64!(($(#[$attr])*) @$M (
+            /// Inner storage type.
+            #[allow(dead_code)]
+            pub type VV = f64;
+            $($tt)*));
+    };
+
+    
+    (@type ($(#[$attr:meta])*) @$M:ident NotNanf32 ($($tt:tt)*)) => {
+        storage_type_notnanf32!(($(#[$attr])*) @$M (
+            /// Inner storage type.
+            #[allow(dead_code)]
+            pub type VV = f32;
+            $($tt)*));
+    };
+    (@type ($(#[$attr:meta])*) @$M:ident NotNanf64 ($($tt:tt)*)) => {
+        storage_type_notnanf64!(($(#[$attr])*) @$M (
+            /// Inner storage type.
+            #[allow(dead_code)]
+            pub type VV = f64;
+            $($tt)*));
+    };
+
     (@type ($(#[$attr:meta])*) @$M:ident f32 ($($tt:tt)*)) => {
         storage_type_f32!(($(#[$attr])*) @$M ($($tt)*));
     };
@@ -142,6 +173,10 @@ macro_rules! storage_types {
         storage_types!(@type ($(#[$attr])*) @$M BigRational ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M Complex32 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M Complex64 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf64 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf64 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M f32 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M f64 ($($tt)*));
     };
@@ -181,6 +216,10 @@ macro_rules! storage_types {
         storage_types!(@type ($(#[$attr])*) @$M Rational32 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M Rational64 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M BigRational ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf64 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf64 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M f32 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M f64 ($($tt)*));
     };
@@ -196,6 +235,14 @@ macro_rules! storage_types {
     (@type ($(#[$attr:meta])*) @$M:ident Complex ($($tt:tt)*)) => {
         storage_types!(@type ($(#[$attr])*) @$M Complex32 ($($tt)*));
         storage_types!(@type ($(#[$attr])*) @$M Complex64 ($($tt)*));
+    };
+    (@type ($(#[$attr:meta])*) @$M:ident OrderedFloat ($($tt:tt)*)) => {
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M Orderedf64 ($($tt)*));
+    };
+    (@type ($(#[$attr:meta])*) @$M:ident NotNan ($($tt:tt)*)) => {
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf32 ($($tt)*));
+        storage_types!(@type ($(#[$attr])*) @$M NotNanf64 ($($tt)*));
     };
     (@mod ($(#[$attr:meta])*) $M:ident, $V:ty; ($($tt:tt)*)) => {
         $(#[$attr])*
@@ -268,6 +315,10 @@ storage_type_types! {
     storage_type_bigrational!("bigrational", bigrational, $crate::num::BigRational);
     storage_type_complex32!("complex32", complex32, $crate::num::complex::Complex32);
     storage_type_complex64!("complex64", complex64, $crate::num::complex::Complex64);
+    storage_type_orderedf32!("orderedf32", orderedf32, $crate::num::ordered_float::Orderedf32);
+    storage_type_orderedf64!("orderedf64", orderedf64, $crate::num::ordered_float::Orderedf64);
+    storage_type_notnanf32!("notnanf32", notnanf32, $crate::num::ordered_float::NotNanf32);
+    storage_type_notnanf64!("notnanf64", notnanf64, $crate::num::ordered_float::NotNanf64);
     storage_type_f32!("f32", f32, f32);
     storage_type_f64!("f64", f64, f64);
 }

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -164,3 +164,27 @@ storage_types! {
     assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
         Binary, Eq, Hash, LowerHex, Octal, Ord, PartialEq, PartialOrd, UpperHex);
 }
+
+storage_types! {
+    types: OrderedFloat, NotNan;
+
+    use super::*;
+
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        Clone, Copy, Debug, PartialEq, PartialOrd, Send, Sync, Unpin, Eq, Ord, Hash);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        RefUnwindSafe, UnwindSafe);
+    assert_not_impl_any!(Quantity<Q<Z0, Z0, Z0>, U<V>, V>:
+        Binary, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex);
+
+
+    //TODO: come back here and fix this!
+    //assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+    //    Clone, Copy, Debug, Display, LowerExp, Send, Sync, Unpin, UpperExp);
+    //#[cfg(feature = "std")]
+    //assert_impl_all!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+    //    RefUnwindSafe, UnwindSafe);
+    //assert_not_impl_any!(QuantityArguments<Q<Z0, Z0, Z0>, U<V>, V, meter>:
+    //    Binary, Eq, Hash, LowerHex, Octal, Ord, PartialEq, PartialOrd, UpperHex);
+}

--- a/src/tests/quantity.rs
+++ b/src/tests/quantity.rs
@@ -285,7 +285,7 @@ mod fmt {
 #[cfg(feature = "autoconvert")]
 mod non_big {
     storage_types! {
-        types: Float, PrimInt, Rational, Rational32, Rational64;
+        types: Float, PrimInt, Rational, Rational32, Rational64, OrderedFloat;
 
         use crate::tests::*;
 
@@ -496,7 +496,7 @@ mod float {
 mod non_complex {
     storage_types! {
         // Everything BUT complex
-        types: PrimInt, Ratio, Float, BigInt, BigUint;
+        types: PrimInt, Ratio, Float, BigInt, BigUint, OrderedFloat, NotNan;
 
         use crate::tests::*;
 

--- a/src/tests/system.rs
+++ b/src/tests/system.rs
@@ -239,7 +239,7 @@ mod prim_int {
 
 mod float {
     storage_types! {
-        types: Float;
+        types: Float, OrderedFloat;
 
         use crate::tests::*;
 
@@ -362,14 +362,21 @@ mod float {
 
             #[allow(trivial_casts)]
             fn max(l: A<V>, r: A<V>) -> bool {
-                Test::eq(&Length::new::<meter>(l.max(*r)),
+                let lr_max = num_traits::float::FloatCore::max(*l, *r);
+                Test::eq(
+                    &Length::new::<meter>(lr_max),
+                    //&Length::new::<meter>(l.max(*r)),
                     &Length::new::<meter>(*l).max(Length::new::<meter>(*r)))
             }
 
             #[allow(trivial_casts)]
             fn min(l: A<V>, r: A<V>) -> bool {
-                Test::eq(&Length::new::<meter>(l.min(*r)),
-                    &Length::new::<meter>(*l).min(Length::new::<meter>(*r)))
+                let lr_min = num_traits::float::FloatCore::min(*l, *r);
+                Test::eq(
+                    //&Length::new::<meter>(l.min(*r)),
+                    &Length::new::<meter>(lr_min),
+                    &Length::new::<meter>(*l).min(Length::new::<meter>(*r))
+                )
             }
         }
     }
@@ -407,7 +414,7 @@ mod signed {
 
 mod non_ratio {
     storage_types! {
-        types: PrimInt, BigInt, BigUint, Float;
+        types: PrimInt, BigInt, BigUint, Float, OrderedFloat, NotNan;
 
         use crate::tests::*;
 
@@ -422,7 +429,7 @@ mod non_ratio {
 
 mod non_big {
     storage_types! {
-        types: PrimInt, Rational, Rational32, Rational64, Float;
+        types: PrimInt, Rational, Rational32, Rational64, Float, OrderedFloat;
 
         use crate::tests::*;
 
@@ -697,7 +704,7 @@ mod complex {
 
 mod non_complex {
     storage_types! {
-        types: PrimInt, Float, Ratio, BigInt, BigUint;
+        types: PrimInt, Float, Ratio, BigInt, BigUint, OrderedFloat, NotNan;
 
         use crate::tests::*;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -363,7 +363,43 @@ macro_rules! unit {
                 }
             })+
         }
+
+        storage_types! {
+            types: OrderedFloat, NotNan;
+
+            $(impl $crate::Conversion<V> for super::$unit {
+                type T = VV;
+
+                #[inline(always)]
+                #[allow(clippy::inconsistent_digit_grouping)]
+                fn coefficient() -> Self::T {
+                    unit!(@coefficient $($conversion),+)
+                }
+
+                #[inline(always)]
+                #[allow(unused_variables)]
+                #[allow(clippy::inconsistent_digit_grouping)]
+                fn constant(op: $crate::ConstantOp) -> Self::T {
+                    unit!(@constant op $($conversion),+)
+                }
+            }
+
+            impl super::Conversion<V> for super::$unit {
+                #[cfg(test)]
+                #[inline(always)]
+                fn is_valid() -> bool {
+                    use $crate::num::ToPrimitive;
+
+                    let r =  Some(unit!(@coefficient $($conversion),+));
+                    let c =  <Self as $crate::Conversion<V>>::coefficient().to_f64();
+
+                    r == c
+                }
+            })+
+        }
+
     };
+
     (@unit $(#[$unit_attr:meta])+ @$unit:ident $plural:expr) => {
         $(#[$unit_attr])*
         #[allow(non_camel_case_types)]

--- a/tests/temp.rs
+++ b/tests/temp.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "notnanf32")]
+mod notnan {
+    use uom::si::notnanf32::*;
+    use uom::num::ordered_float::NotNan;
+    use uom::si::length::{kilometer, meter};
+
+    #[test]
+    fn test_not_nan32() {
+        let x = Length::new::<kilometer>(NotNan(5.0));
+
+        x.is_nan();
+        x.is_finite();
+        x.is_infinite();
+        //x.sqrt();
+        //x.cbrt();
+    }
+
+}
+
+#[cfg(feature = "orderedf32")]
+mod order32 {
+use uom::si::orderedf32::*;
+use uom::num::ordered_float::OrderedFloat;
+use uom::si::length::{kilometer, meter};
+
+#[test]
+fn test_of32() {
+    let x = Length::new::<kilometer>(OrderedFloat(5.0));
+    assert_eq!(x.get::<meter>(), OrderedFloat(5000.0));
+
+    let x2 = x * x;
+    let x3 = x * x * x;
+
+    x.is_nan();
+    x.is_finite();
+    x.is_infinite();
+    //x2.sqrt();
+    //x3.cbrt();
+}
+
+#[test]
+fn foo() {
+    let x = &30.0 % & 10.0;
+
+    let a = ordered_float::OrderedFloat(30.0);
+    let b = ordered_float::OrderedFloat(10.0);
+    let xx = &a %  &b;
+
+}
+}


### PR DESCRIPTION
Related to issue #208 

Working on optional lib features to handle ordered_float wrapper types natively.

This draft is probably 90% of the way there but there are a few design decisions still to make, and a lot of polishing to be done.