### PR TITLE
feat: impl Error for TryFromError

### DIFF
--- a/src/si/time.rs
+++ b/src/si/time.rs
@@ -1,5 +1,6 @@
 //! Time (base unit second, s).
 
+use crate::lib::fmt::{self, Display, Formatter};
 use crate::lib::time::Duration;
 use crate::num::{FromPrimitive, ToPrimitive, Zero};
 
@@ -66,6 +67,20 @@ pub enum TryFromError {
     /// The given time interval exceeded the maximum size of a `Duration`.
     Overflow,
 }
+
+impl Display for TryFromError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use TryFromError::{NegativeDuration, Overflow};
+
+        match *self {
+            NegativeDuration => write!(f, "time interval was negative"),
+            Overflow => write!(f, "time interval exceeded the maximum size of a `Duration`"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl crate::lib::error::Error for TryFromError {}
 
 /// Attempt to convert the given `Time` to a `Duration`.
 ///


### PR DESCRIPTION
This implements the [`error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html) trait on the [`TryFromError`](https://docs.rs/uom/latest/uom/si/time/enum.TryFromError.html) enum.

---

The only other error type in `uom` is [`ParseQuantityError`](https://docs.rs/uom/latest/uom/str/enum.ParseQuantityError.html), which already implements `Error`. I copied the same structure for implementing `Error` on this type, modifying the error messages appropriately.

The reason I am proposing this change is because I recently found myself wanting to write a function like this:
```rust
fn uom_time_str_to_std_duration(s: &str) -> anyhow::Result<std::time::Duration> {
    let time: uom::si::f64::Time = s.parse()?;
    let duration = time.try_into()?;
    Ok(duration)
}
```

However, this function does not compile, and results in the following error:
```
error[E0277]: the trait bound `TryFromError: std::error::Error` is not satisfied
  --> src/main.rs:15:35
   |
15 |     let duration = time.try_into()?;
   |                                   ^ the trait `std::error::Error` is not implemented for `TryFromError`, which is required by `Result<Duration, anyhow::Error>: FromResidual<Result<Infallible, _>>`
   |
   = help: the trait `FromResidual<Result<Infallible, E>>` is implemented for `Result<T, F>`
   = note: required for `anyhow::Error` to implement `From<TryFromError>`
   = note: required for `Result<Duration, anyhow::Error>` to implement `FromResidual<Result<Infallible, TryFromError>>`

For more information about this error, try `rustc --explain E0277`.
```

This PR resolves this issue.

---

This is my first contribution to `uom`, so if I have missed anything important, please let me know.