### PR TITLE
Remove unnecessary parentheses.

### DIFF
--- a/src/si/angle.rs
+++ b/src/si/angle.rs
@@ -15,7 +15,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         /// SI derived unit of angle. It is the angle subtended at the center of a circle by an
         /// arc that is equal in length to the radius of the circle.

--- a/src/si/angular_absement.rs
+++ b/src/si/angular_absement.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         @radian_second: prefix!(none); "rad · s", "radian second", "radian seconds";
         @degree_second: 1.745_329_251_994_329_5_E-2; "° · s", "degree second", "degree seconds";

--- a/src/si/angular_acceleration.rs
+++ b/src/si/angular_acceleration.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         /// Derived unit of angular acceleration.
         @radian_per_second_squared: 1.0; "rad/s²", "radian per second squared",

--- a/src/si/angular_jerk.rs
+++ b/src/si/angular_jerk.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         /// Derived unit of angular jerk.
         @radian_per_second_cubed: 1.0; "rad/s³", "radian per second cubed",

--- a/src/si/angular_momentum.rs
+++ b/src/si/angular_momentum.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         /// Derived unit of angular velocity.
         @kilogram_square_meter_per_second: prefix!(kilo) / prefix!(kilo); "kg · m²/s",

--- a/src/si/angular_velocity.rs
+++ b/src/si/angular_velocity.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         /// Derived unit of angular velocity.
         @radian_per_second: 1.0_E0; "rad/s", "radian per second", "radians per second";

--- a/src/si/areal_density_of_states.rs
+++ b/src/si/areal_density_of_states.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @state_per_square_meter_joule: prefix!(none); "1/(m² · J)", "state per square meter joule",
             "states per square meter joule";

--- a/src/si/areal_number_density.rs
+++ b/src/si/areal_number_density.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_square_kilometer: prefix!(none) / prefix!(kilo) / prefix!(kilo); "km⁻²",
             "per square kilometer", "per square kilometer";

--- a/src/si/areal_number_rate.rs
+++ b/src/si/areal_number_rate.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_square_meter_second: prefix!(none); "m⁻² · s⁻¹", "per square meter second",
             "per square meter second";

--- a/src/si/catalytic_activity_concentration.rs
+++ b/src/si/catalytic_activity_concentration.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         P1,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @yottakatal_per_cubic_meter: prefix!(yotta); "Ykat/m³",
             "yottakatal per cubic meter", "yottakatals per cubic meter";

--- a/src/si/curvature.rs
+++ b/src/si/curvature.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         @radian_per_meter: 1.0_E0; "rad/m", "radian per meter", "radians per meter";
         @degree_per_meter: 1.745_329_251_994_329_5_E-2; "°/m", "degree per meter",

--- a/src/si/electric_charge_areal_density.rs
+++ b/src/si/electric_charge_areal_density.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-        kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+        kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @coulomb_per_square_meter: prefix!(none); "C/m²", "coulomb per square meter",
             "coulombs per square meter";

--- a/src/si/electric_charge_linear_density.rs
+++ b/src/si/electric_charge_linear_density.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-        kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+        kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @coulomb_per_meter: prefix!(none); "C/m", "coulomb per meter", "coulombs per meter";
         @coulomb_per_centimeter: prefix!(none) / prefix!(centi); "C/cm", "coulomb per centimeter",

--- a/src/si/electric_charge_volumetric_density.rs
+++ b/src/si/electric_charge_volumetric_density.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-        kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+        kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @coulomb_per_cubic_meter: prefix!(none); "C/m³", "coulomb per cubic meter",
             "coulombs per cubic meter";

--- a/src/si/electric_current_density.rs
+++ b/src/si/electric_current_density.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-        kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+        kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @ampere_per_square_meter: prefix!(none); "A/m²", "ampere per square meter",
             "amperes per square meter";

--- a/src/si/illuminance.rs
+++ b/src/si/illuminance.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         P1>;    // luminous intensity
-    kind: dyn (crate::si::marker::IlluminanceKind);
+    kind: dyn crate::si::marker::IlluminanceKind;
     units {
         @yottalux: prefix!(yotta); "Ylx", "yottalux", "yottalux";
         @zettalux: prefix!(zetta); "Zlx", "zettalux", "zettalux";

--- a/src/si/information.rs
+++ b/src/si/information.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::InformationKind);
+    kind: dyn crate::si::marker::InformationKind;
     units {
         // Base-2.
         @yobibit: prefix!(yobi) / 8.0; "Yib", "yobibit", "yobibits";

--- a/src/si/information_rate.rs
+++ b/src/si/information_rate.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::InformationKind);
+    kind: dyn crate::si::marker::InformationKind;
     units {
         @yobibit_per_second: prefix!(yobi) * prefix!(none) / 8.0; "Yib/s", "yobibit per second",
             "yobibits per second";

--- a/src/si/kinematic_viscosity.rs
+++ b/src/si/kinematic_viscosity.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::KinematicViscosityKind);
+    kind: dyn crate::si::marker::KinematicViscosityKind;
     units {
         @square_meter_per_second: prefix!(none);
             "m²/s", "square meter per second", "square meters per second";

--- a/src/si/linear_density_of_states.rs
+++ b/src/si/linear_density_of_states.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @state_per_meter_joule: prefix!(none); "1/(m · J)", "state per meter joule",
             "states per meter joule";

--- a/src/si/linear_number_density.rs
+++ b/src/si/linear_number_density.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_kilometer: prefix!(none) / prefix!(kilo); "km⁻¹", "per kilometer", "per kilometer";
         @per_meter: prefix!(none); "m⁻¹", "per meter", "per meter";

--- a/src/si/linear_number_rate.rs
+++ b/src/si/linear_number_rate.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_kilometer_second: prefix!(none) / prefix!(kilo); "km⁻¹ · s⁻¹", "per kilometer second",
             "per kilometer second";

--- a/src/si/mass_concentration.rs
+++ b/src/si/mass_concentration.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @yottagram_per_cubic_meter: prefix!(yotta) / prefix!(kilo); "Yg/m³",
             "yottagram per cubic meter", "yottagrams per cubic meter";

--- a/src/si/molality.rs
+++ b/src/si/molality.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         P1,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @mole_per_kilogram: prefix!(none); "mol/kg", "mole per kilogram", "moles per kilogram";
     }

--- a/src/si/molar_concentration.rs
+++ b/src/si/molar_concentration.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         P1,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @yottamole_per_cubic_meter: prefix!(yotta); "Ymol/m³",
             "yottamole per cubic meter", "yottamoles per cubic meter";

--- a/src/si/molar_radioactivity.rs
+++ b/src/si/molar_radioactivity.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         N1,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @becquerel_per_mole: prefix!(none); "Bq/mol", "becquerel per mole", "becquerels per mole";
 

--- a/src/si/radioactivity.rs
+++ b/src/si/radioactivity.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @yottabecquerel: prefix!(yotta); "YBq", "yottabecquerel", "yottabecquerels";
         @zettabecquerel: prefix!(zetta); "ZBq", "zettabecquerel", "zettabecquerels";

--- a/src/si/solid_angle.rs
+++ b/src/si/solid_angle.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::SolidAngleKind);
+    kind: dyn crate::si::marker::SolidAngleKind;
     units {
         /// SI derived unit of solid angle is steradians. It is the solid angle subtended at the
         /// center of a unit sphere by a unit area on its surface.

--- a/src/si/specific_radioactivity.rs
+++ b/src/si/specific_radioactivity.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @becquerel_per_kilogram: prefix!(none); "Bq/kg", "becquerel per kilogram",
             "becquerels per kilogram";

--- a/src/si/surface_electric_current_density.rs
+++ b/src/si/surface_electric_current_density.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @ampere_per_meter: prefix!(none); "A/m", "ampere per meter", "amperes per meter";
         @ampere_per_centimeter: prefix!(none) / prefix!(centi) ; "A/cm", "ampere per centimeter",

--- a/src/si/surface_tension.rs
+++ b/src/si/surface_tension.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::SurfaceTensionKind);
+    kind: dyn crate::si::marker::SurfaceTensionKind;
     units {
         @yottanewton_per_meter: prefix!(yotta);
             "YN/m", "yottanewton per meter", "yottanewtons per meter";

--- a/src/si/thermodynamic_temperature.rs
+++ b/src/si/thermodynamic_temperature.rs
@@ -59,7 +59,7 @@ quantity! {
         P1,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::TemperatureKind);
+    kind: dyn crate::si::marker::TemperatureKind;
     units {
         @yottakelvin: prefix!(yotta); "YK", "yottakelvin", "yottakelvins";
         @zettakelvin: prefix!(zetta); "ZK", "zettakelvin", "zettakelvins";

--- a/src/si/torque.rs
+++ b/src/si/torque.rs
@@ -17,7 +17,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::AngleKind);
+    kind: dyn crate::si::marker::AngleKind;
     units {
         @yottanewton_meter: prefix!(yotta); "YN · m", "yottanewton meter", "yottanewton meters";
         @zettanewton_meter: prefix!(zetta); "ZN · m", "zettanewton meter", "zettanewton meters";

--- a/src/si/volumetric_density_of_states.rs
+++ b/src/si/volumetric_density_of_states.rs
@@ -13,7 +13,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @state_per_cubic_meter_joule: prefix!(none); "1/(m³ · J)",
             "state per cubic meter joule", "states per cubic meter joule";

--- a/src/si/volumetric_number_density.rs
+++ b/src/si/volumetric_number_density.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_cubic_kilometer: prefix!(none) / prefix!(kilo) / prefix!(kilo) / prefix!(kilo); "km⁻³",
             "per cubic kilometer", "per cubic kilometer";

--- a/src/si/volumetric_number_rate.rs
+++ b/src/si/volumetric_number_rate.rs
@@ -12,7 +12,7 @@ quantity! {
         Z0,     // thermodynamic temperature
         Z0,     // amount of substance
         Z0>;    // luminous intensity
-    kind: dyn (crate::si::marker::ConstituentConcentrationKind);
+    kind: dyn crate::si::marker::ConstituentConcentrationKind;
     units {
         @per_cubic_meter_second: prefix!(none); "m⁻³ · s⁻¹",
             "per cubic meter second", "per cubic meter second";


### PR DESCRIPTION
Compiling with nightly I get lots of warnings like this:
```
warning: unnecessary parentheses around type
  --> src/si/angle.rs:18:15
   |
18 |     kind: dyn (crate::si::marker::AngleKind);
   |               ^                            ^
   |
   = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
   |
18 -     kind: dyn (crate::si::marker::AngleKind);
18 +     kind: dyn crate::si::marker::AngleKind;
   |
```
This commit removes the unnecessary parentheses.