### PR TITLE
Re-enable `clippy::inconsistent_digit_grouping` lint.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,16 +171,8 @@
 // Clippy lints.
 #![cfg_attr(
     clippy,
-    warn(
-        clippy::must_use_candidate,
-        clippy::return_self_not_must_use,
-    ),
-    allow(
-        clippy::deprecated_cfg_attr,
-        clippy::excessive_precision,
-        clippy::inconsistent_digit_grouping, // https://github.com/rust-lang/rust-clippy/issues/6096
-        clippy::inline_always,
-    )
+    warn(clippy::must_use_candidate, clippy::return_self_not_must_use),
+    allow(clippy::deprecated_cfg_attr, clippy::excessive_precision, clippy::inline_always)
 )]
 // Lints allowed in tests because they are unavoidable in the generic code when a type may or may
 // not need to be dereferenced or cloned.

--- a/src/si/specific_volume.rs
+++ b/src/si/specific_volume.rs
@@ -70,7 +70,7 @@ quantity! {
             "cubic meter per ounce", "cubic meters per ounce";
         @cubic_meter_per_ounce_troy: 3.215_074_326_088_270_6_E1; "m³/oz t",
             "cubic meter per troy ounce", "cubic meters per troy ounce";
-        @cubic_meter_per_pennyweight: 6.430_14_865_217_654_E2; "m³/dwt",
+        @cubic_meter_per_pennyweight: 6.430_148_652_176_54_E2; "m³/dwt",
             "cubic meter per pennyweight", "cubic meters per pennyweight";
         @cubic_meter_per_pound: 2.204_622_476_037_958_5_E0; "m³/lb",
             "cubic meter per pound", "cubic meters per pound";
@@ -100,7 +100,7 @@ quantity! {
             "Imperial gallon per ounce", "Imperial gallons per ounce";
         @gallon_per_ounce: 1.335_264_935_702_615_E-1; "gal/oz", "gallon per ounce",
             "gallons per ounce";
-        @cubic_foot_per_pound: 6.24_279_639_605_954_6_E-2; "ft³/lb", "cubic foot per pound",
+        @cubic_foot_per_pound: 6.242_796_396_059_546_E-2; "ft³/lb", "cubic foot per pound",
             "cubic feet per pound";
         @cubic_inch_per_pound: 3.612_728_079_218_259_E-5; "in³/lb", "cubic inch per pound",
             "cubic inches per pound";

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -147,14 +147,12 @@ macro_rules! unit {
                 type T = V;
 
                 #[inline(always)]
-                #[allow(clippy::inconsistent_digit_grouping)]
                 fn coefficient() -> Self::T {
                     unit!(@coefficient $($conversion),+)
                 }
 
                 #[inline(always)]
                 #[allow(unused_variables)]
-                #[allow(clippy::inconsistent_digit_grouping)]
                 fn constant(op: $crate::ConstantOp) -> Self::T {
                     unit!(@constant op $($conversion),+)
                 }
@@ -337,14 +335,12 @@ macro_rules! unit {
                 type T = VV;
 
                 #[inline(always)]
-                #[allow(clippy::inconsistent_digit_grouping)]
                 fn coefficient() -> Self::T {
                     unit!(@coefficient $($conversion),+)
                 }
 
                 #[inline(always)]
                 #[allow(unused_variables)]
-                #[allow(clippy::inconsistent_digit_grouping)]
                 fn constant(op: $crate::ConstantOp) -> Self::T {
                     unit!(@constant op $($conversion),+)
                 }


### PR DESCRIPTION
It was disabled because of a shortcoming
(https://github.com/rust-lang/rust-clippy/issues/6096), but that has long since been fixed.

The commit also fixes two violations that crept in. I am assuming that the numbers are correct and it's just the separators are in the wrong places.