### PR TITLE
Add clamp()

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -748,6 +748,20 @@ macro_rules! system {
                     value: self.value.min(other.value),
                 }
             }
+
+            /// Restrict a value to a certain interval.
+            #[must_use = "method returns a new number and does not mutate the original value"]
+            #[inline(always)]
+            pub fn clamp(self, min: Self, max: Self) -> Self
+            where
+                V: $crate::num::Float,
+            {
+                Quantity {
+                    dimension: $crate::lib::marker::PhantomData,
+                    units: $crate::lib::marker::PhantomData,
+                    value: self.value.clamp(min.value, max.value),
+                }
+            }
         }
 
         // Explicitly definte floating point methods for float and complex storage types.
@@ -1070,6 +1084,15 @@ macro_rules! system {
                     dimension: $crate::lib::marker::PhantomData,
                     units: $crate::lib::marker::PhantomData,
                     value: self.value.min(other.value),
+                }
+            }
+
+            #[inline(always)]
+            fn clamp(self, min: Self, max: Self) -> Self {
+                Quantity {
+                    dimension: $crate::lib::marker::PhantomData,
+                    units: $crate::lib::marker::PhantomData,
+                    value: self.value.clamp(min.value, max.value),
                 }
             }
         }

--- a/src/tests/system.rs
+++ b/src/tests/system.rs
@@ -371,6 +371,16 @@ mod float {
                 Test::eq(&Length::new::<meter>(l.min(*r)),
                     &Length::new::<meter>(*l).min(Length::new::<meter>(*r)))
             }
+
+            #[allow(trivial_casts)]
+            fn clamp(v: A<V>, a: A<V>, b: A<V>) -> bool {
+                let mn = a.min(*b);
+                let mx = a.max(*b);
+                Test::eq(
+                    &Length::new::<meter>(v.clamp(mn, mx)),
+                    &Length::new::<meter>(*v).clamp(Length::new::<meter>(mn), Length::new::<meter>(mx))
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
UoM already has `min()` and `max()`, but seems to be missing `clamp()`. So I added it.

