### PR TITLE
Correct `doc_example!` to properly run/ignore documentation tests.

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -49,29 +49,21 @@ macro_rules! not_autoconvert {
     ($($tt:tt)*) => { $($tt)* };
 }
 
-/// Expands to a rust doc test when `uom` is compiled with the `si` and `f32` features and the macro
-/// is called from within the `uom` crate.
+/// Expands to a rust doc test when `uom` is compiled with the `si` and `f32` features.
 ///
 /// Examples:
-/// `#[doc = doc_example($crate)]`.
-/// `#[doc = doc_example($crate, "compile_fail")]`.
+/// `#[doc = doc_example()]`.
+/// `#[doc = doc_example("compile_fail")]`.
 #[doc(hidden)]
 #[macro_export]
 #[cfg(all(feature = "si", feature = "f32"))]
 macro_rules! doc_example {
-    (::uom) => {
-        " ```rust"
-    };
-    (::uom, $options:literal) => {
-        concat!(" ```rust,", $options)
-    };
-    ($($tt:tt)*) => {
-        " ```rust,ignore"
+    ($($options:literal)?) => {
+        concat!(" ```rust" $(, ",", $options)?, "\n # extern crate uom;")
     };
 }
 
-/// Expands to an ignored rust doc test when `uom` is compiled without the `si` or `f32` features
-/// regardless of which crate the macro is called from.
+/// Expands to an ignored rust doc test when `uom` is compiled without the `si` or `f32` features.
 #[doc(hidden)]
 #[macro_export]
 #[cfg(not(all(feature = "si", feature = "f32")))]

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -324,7 +324,7 @@ macro_rules! quantity {
             /// [`into_format_args`](#method.into_format_args) instead.
             ///
             /// # Examples
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::time::{femtosecond, picosecond};
             /// # use uom::si::fmt::Arguments;
@@ -365,7 +365,7 @@ macro_rules! quantity {
             /// [`format_args`](#method.format_args) instead.
             ///
             /// # Examples
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::time::{femtosecond, picosecond};
             /// # use uom::si::fmt::Arguments;

--- a/src/system.rs
+++ b/src/system.rs
@@ -191,7 +191,7 @@ macro_rules! system {
         /// which is generic over the input unit and accepts the input value as it's only
         /// parameter.
         ///
-        #[doc = doc_example!($crate)]
+        #[doc = doc_example!()]
         /// # use uom::si::f32::*;
         /// # use uom::si::length::meter;
         /// // Create a length of 1 meter.
@@ -203,7 +203,7 @@ macro_rules! system {
         /// once the [`const fn`](https://github.com/rust-lang/rust/issues/24111) feature is
         /// stabilized.
         ///
-        #[doc = doc_example!($crate)]
+        #[doc = doc_example!()]
         /// # use uom::si::{Quantity, ISQ, SI};
         /// # use uom::si::f32::*;
         /// # use uom::lib::marker::PhantomData;
@@ -217,7 +217,7 @@ macro_rules! system {
         ///
         /// Using units for the wrong quantity will cause a compile error:
         ///
-        #[doc = doc_example!($crate, "compile_fail")]
+        #[doc = doc_example!("compile_fail")]
         /// # use uom::si::f32::*;
         /// # use uom::si::time::second;
         /// // error[E0277]: the trait bound `second: length::Unit` is not satisfied
@@ -226,7 +226,7 @@ macro_rules! system {
         ///
         /// Mixing quantities will also cause a compile error:
         ///
-        #[doc = doc_example!($crate, "compile_fail")]
+        #[doc = doc_example!("compile_fail")]
         /// # use uom::si::f32::*;
         /// # use uom::si::length::meter;
         /// # use uom::si::time::second;
@@ -234,7 +234,7 @@ macro_rules! system {
         /// let r = Length::new::<meter>(1.0) + Time::new::<second>(1.0);
         /// ```
         ///
-        #[doc = doc_example!($crate, "compile_fail")]
+        #[doc = doc_example!("compile_fail")]
         /// # use uom::si::f32::*;
         /// # use uom::si::length::meter;
         /// # use uom::si::time::second;
@@ -696,7 +696,7 @@ macro_rules! system {
 
             /// Takes the reciprocal (inverse) of a number, `1/x`.
             ///
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::time::second;
             /// let f: Frequency = Time::new::<second>(1.0).recip();
@@ -802,7 +802,7 @@ macro_rules! system {
                     std! {
                     /// Takes the cubic root of a number.
                     ///
-                    #[doc = doc_example!($crate)]
+                    #[doc = doc_example!()]
                     /// # use uom::si::f32::*;
                     /// # use uom::si::volume::cubic_meter;
                     /// let l: Length = Volume::new::<cubic_meter>(8.0).cbrt();
@@ -810,7 +810,7 @@ macro_rules! system {
                     ///
                     /// The input type must have dimensions divisible by three:
                     ///
-                    #[doc = doc_example!($crate, "compile_fail")]
+                    #[doc = doc_example!("compile_fail")]
                     /// # use uom::si::f32::*;
                     /// # use uom::si::area::square_meter;
                     /// // error[E0271]: type mismatch resolving ...
@@ -872,7 +872,7 @@ macro_rules! system {
 
                     /// Raises a quantity to an integer power.
                     ///
-                    #[doc = doc_example!($crate)]
+                    #[doc = doc_example!()]
                     /// # use uom::si::f32::*;
                     /// # use uom::si::length::meter;
                     /// use uom::typenum::P2;
@@ -903,7 +903,7 @@ macro_rules! system {
                     /// Takes the square root of a number. Returns `NAN` if `self` is a negative
                     /// number.
                     ///
-                    #[doc = doc_example!($crate)]
+                    #[doc = doc_example!()]
                     /// # use uom::si::f32::*;
                     /// # use uom::si::area::square_meter;
                     /// let l: Length = Area::new::<square_meter>(4.0).sqrt();
@@ -911,7 +911,7 @@ macro_rules! system {
                     ///
                     /// The input type must have dimensions divisible by two:
                     ///
-                    #[doc = doc_example!($crate, "compile_fail")]
+                    #[doc = doc_example!("compile_fail")]
                     /// # use uom::si::f32::*;
                     /// # use uom::si::length::meter;
                     /// // error[E0271]: type mismatch resolving ...
@@ -1378,7 +1378,7 @@ macro_rules! system {
             ///
             /// # Usage
             /// ## Indirect style
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::length::{centimeter, meter};
             /// # use uom::si::fmt::Arguments;
@@ -1390,7 +1390,7 @@ macro_rules! system {
             /// ```
             ///
             /// ## Direct style
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::length::{centimeter, meter};
             /// # use uom::si::fmt::Arguments;
@@ -1417,7 +1417,7 @@ macro_rules! system {
 
             /// A struct to specify a display style and unit for a given quantity.
             ///
-            #[doc = doc_example!($crate)]
+            #[doc = doc_example!()]
             /// # use uom::si::f32::*;
             /// # use uom::si::length::{centimeter, meter};
             /// # use uom::si::fmt::Arguments;


### PR DESCRIPTION
The original attempt to avoid running documentation tests in third-party crates to stop unexpected cfg condition compiler warnings was flawed and ignored *all* documentation tests, even in `uom` directly. The latest changes will now properly generate run/ignore documentation tests based on `uom` feature selection without causing unexpected cfg condition compiler warnings. While not ideal, this does includes third-party crates.