### PR TITLE
Add `data_mile` unit of length

### DIFF
--- a/src/si/length.rs
+++ b/src/si/length.rs
@@ -45,6 +45,7 @@ quantity! {
             "atomic units of length";
         @astronomical_unit: 1.495_979_E11; "ua", "astronomical unit", "astronomical units";
         @chain: 2.011_684_E1; "ch", "chain", "chains";
+        @data_mile: 1.828_8_E3; "DM", "data mile", "data miles";
         @fathom: 1.828_804_E0; "fathom", "fathom", "fathoms";
         @fermi: 1.0_E-15; "fermi", "fermi", "fermis";
         @foot: 3.048_E-1; "ft", "foot", "feet";


### PR DESCRIPTION
Data miles are commonly used in fields involving radar technology. They are defined as a length of 6000 ft; converted to meters results in 1828.8 m.

For the abbreviation, there is no official abbreviation that I could find online or through any official documentation, though I have seen both "DM" and "data mi" used professionally while working with radars.