### PR TITLE
serde: Generate `serialize()` and `deserialize()` fns for each unit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -299,6 +300,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "quickcheck",
+ "serde",
  "serde_core",
  "serde_json",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ typenum = "1.13"
 [dev-dependencies]
 approx = "0.5"
 quickcheck = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 static_assertions = "1.1"
 

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -147,6 +147,8 @@ macro_rules! quantity {
                 $abbreviation, $singular, $plural;)+
         }
 
+        unit_serde! { $quantity; $($unit),+ }
+
         /// Quantity description.
         #[must_use = "method returns a static value"]
         #[allow(dead_code)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -266,4 +266,6 @@ mod a_struct {
 mod asserts;
 mod quantities;
 mod quantity;
+#[cfg(feature = "serde")]
+mod serde;
 mod system;

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1,0 +1,52 @@
+//! Tests for unit `serialize` and `deserialize` functions.
+
+// We re-export `serde_core` as `serde` in `lib.rs`, which shadows the `serde` crate.
+extern crate serde as serde_with_derive;
+
+storage_types! {
+    types: Float, PrimInt;
+
+    use crate::tests::*;
+    use super::serde_with_derive::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Component {
+        length: length::Length<U<V>, V>,
+
+        #[serde(serialize_with = "length::meter::serialize")]
+        #[serde(deserialize_with = "length::meter::deserialize")]
+        length_m: length::Length<U<V>, V>,
+
+        #[serde(serialize_with = "length::kilometer::serialize")]
+        #[serde(deserialize_with = "length::kilometer::deserialize")]
+        length_km: length::Length<U<V>, V>,
+    }
+
+    #[test]
+    fn deserialize() {
+        let json = r#"{ "length": 2000, "length_m": 3000, "length_km": 5 }"#;
+        let component: Component = serde_json::from_str(json).unwrap();
+
+        Test::assert_eq(&V::from_f64(2000.0).unwrap(), &component.length.get::<meter>());
+        Test::assert_eq(&V::from_f64(2.0).unwrap(), &component.length.get::<kilometer>());
+        Test::assert_eq(&V::from_f64(3000.0).unwrap(), &component.length_m.get::<meter>());
+        Test::assert_eq(&V::from_f64(3.0).unwrap(), &component.length_m.get::<kilometer>());
+        Test::assert_eq(&V::from_f64(5.0).unwrap(), &component.length_km.get::<kilometer>());
+        Test::assert_eq(&V::from_f64(5000.0).unwrap(), &component.length_km.get::<meter>());
+    }
+
+    #[test]
+    fn serialize() {
+        let component = Component {
+            length: length::Length::new::<meter>(V::from_f64(2000.0).unwrap()),
+            length_m: length::Length::new::<meter>(V::from_f64(3000.0).unwrap()),
+            length_km: length::Length::new::<kilometer>(V::from_f64(5.0).unwrap()),
+        };
+
+        let json = serde_json::to_value(&component).unwrap();
+
+        assert_eq!(json["length"], serde_json::to_value(V::from_f64(2000.0).unwrap()).unwrap());
+        assert_eq!(json["length_m"], serde_json::to_value(V::from_f64(3000.0).unwrap()).unwrap());
+        assert_eq!(json["length_km"], serde_json::to_value(V::from_f64(5.0).unwrap()).unwrap());
+    }
+}


### PR DESCRIPTION
This adds a private `unit_serde!` macro to automatically generate unit-specific serialization and deserialization functions when the `serde` feature is enabled. These functions are generic over storage types (f32, f64, etc.) and can be used with serde's `serialize_with` and `deserialize_with` attributes to handle JSON values in non-base units:

```rust
#[derive(Serialize, Deserialize)]
struct MyStruct {
    #[serde(serialize_with = "millimeter::serialize")]
    #[serde(deserialize_with = "millimeter::deserialize")]
    width: uom::si::f64::Length,
}
```