### PR TITLE
Remove unnecessary unit struct fields from `Units` enum variants

### DIFF
--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -163,7 +163,7 @@ macro_rules! quantity {
         pub enum Units {
             $(#[allow(clippy::empty_docs)] // macros cannot expand to enum variants
             #[doc=$plural]
-            $unit($unit),)+
+            $unit,)+
         }
 
         impl Units {
@@ -172,7 +172,7 @@ macro_rules! quantity {
             #[allow(dead_code)]
             pub fn abbreviation(&self) -> &'static str {
                 match self {
-                    $(Units::$unit(_) => $abbreviation,)+
+                    $(Units::$unit => $abbreviation,)+
                 }
             }
 
@@ -181,7 +181,7 @@ macro_rules! quantity {
             #[allow(dead_code)]
             pub fn singular(&self) -> &'static str {
                 match self {
-                    $(Units::$unit(_) => $singular,)+
+                    $(Units::$unit => $singular,)+
                 }
             }
 
@@ -190,13 +190,13 @@ macro_rules! quantity {
             #[allow(dead_code)]
             pub fn plural(&self) -> &'static str {
                 match self {
-                    $(Units::$unit(_) => $plural,)+
+                    $(Units::$unit => $plural,)+
                 }
             }
         }
 
         static ALL_UNITS: &[Units] = &[
-            $(Units::$unit($unit),)+
+            $(Units::$unit,)+
         ];
 
         /// Iterate over all defined units for this quantity.

--- a/src/tests/quantities.rs
+++ b/src/tests/quantities.rs
@@ -38,23 +38,23 @@ fn plural() {
 
 #[test]
 fn units_abbreviation() {
-    assert_eq!("km", length::Units::kilometer(kilometer).abbreviation());
-    assert_eq!("m", length::Units::meter(meter).abbreviation());
-    assert_eq!("kg", mass::Units::kilogram(kilogram).abbreviation());
+    assert_eq!("km", length::Units::kilometer.abbreviation());
+    assert_eq!("m", length::Units::meter.abbreviation());
+    assert_eq!("kg", mass::Units::kilogram.abbreviation());
 }
 
 #[test]
 fn units_singular() {
-    assert_eq!("kilometer", length::Units::kilometer(kilometer).singular());
-    assert_eq!("meter", length::Units::meter(meter).singular());
-    assert_eq!("kilogram", mass::Units::kilogram(kilogram).singular());
+    assert_eq!("kilometer", length::Units::kilometer.singular());
+    assert_eq!("meter", length::Units::meter.singular());
+    assert_eq!("kilogram", mass::Units::kilogram.singular());
 }
 
 #[test]
 fn units_plural() {
-    assert_eq!("kilometers", length::Units::kilometer(kilometer).plural());
-    assert_eq!("meters", length::Units::meter(meter).plural());
-    assert_eq!("kilograms", mass::Units::kilogram(kilogram).plural());
+    assert_eq!("kilometers", length::Units::kilometer.plural());
+    assert_eq!("meters", length::Units::meter.plural());
+    assert_eq!("kilograms", mass::Units::kilogram.plural());
 }
 
 #[test]


### PR DESCRIPTION
The unit struct fields in `Units` enum variants were never accessed - they were only used for construction and immediately discarded in pattern matching.

Changes:
- Convert tuple-like enum variants (e.g., `steradian(steradian)`) to unit-like variants (e.g., `steradian`)
- Update pattern matching to use simpler syntax without wildcards
- Update `ALL_UNITS` initialization to use unit-like syntax
- Update tests to construct enum variants without passing unit structs

Benefits:
- Simpler, clearer API
- Smaller enum variants (no tuple wrapper)
- Less confusion about unused fields

Breaking change: External code constructing `Units` enum variants must use unit-like syntax instead of tuple-like syntax.

Fixes #539