### PR TITLE
Use `serde_core` instead of `serde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "quickcheck",
- "serde",
+ "serde_core",
  "serde_json",
  "static_assertions",
  "typenum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ num-traits = { version = "0.2", default-features = false }
 num-rational = { version = "0.4", optional = true, default-features = false }
 num-bigint = { version = "0.4", optional = true, default-features = false, features = ["std"] }
 num-complex = { version = "0.4", optional = true, default-features = false, features = ["std"] }
-serde = { version = "1.0", optional = true, default-features = false }
+serde_core = { version = "1.0", optional = true, default-features = false }
 typenum = "1.13"
 
 [dev-dependencies]
@@ -68,7 +68,7 @@ f32 = []
 f64 = []
 si = []
 std = ["num-traits/std"]
-serde = ["dep:serde", "num-rational?/serde", "num-bigint?/serde", "num-complex?/serde"]
+serde = ["dep:serde_core", "num-rational?/serde", "num-bigint?/serde", "num-complex?/serde"]
 # The try-from feature is deprecated and will be removed in a future release of uom. Functionality
 # previously exposed by the feature is now enabled by default.
 try-from = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub extern crate num_complex;
 
 #[doc(hidden)]
 #[cfg(feature = "serde")]
-pub extern crate serde;
+pub extern crate serde_core as serde;
 
 #[doc(hidden)]
 pub extern crate typenum;


### PR DESCRIPTION
Replace the `serde` dependency with `serde_core` to improve build times. Since the crate only hand-implements Serialize/Deserialize traits without using derive macros, `serde_core` is sufficient and allows parallel compilation with `serde_derive`.

see https://github.com/serde-rs/serde/tree/v1.0.228/serde_core